### PR TITLE
chore: sync develop with main (10+ commits behind)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+
+updates:
+  # ── Dependencias de GitHub Actions ─────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+
+  # ── Dependencias de Cargo (Rust) ────────────────────────────────────────────
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "build(deps)"
+    # Agrupar todas las actualizaciones de crates de RustCrypto en un solo PR
+    groups:
+      rust-crypto:
+        patterns:
+          - "aes-gcm"
+          - "sha3"
+          - "zeroize"
+          - "subtle"
+          - "rand_core"
+          - "thiserror"
+      pyo3:
+        patterns:
+          - "pyo3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,11 @@
 name: Release to PyPI
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Disparadores:
+#   • v*rc*  → publica en TestPyPI  (ej: v0.1.0rc1, v0.2.0rc2)
+#   • v*     → publica en PyPI prod (ej: v0.1.0, v1.0.0)
+#             (los tags rc* quedan excluidos por la condición del job publish)
+# ─────────────────────────────────────────────────────────────────────────────
 on:
   push:
     tags:
@@ -9,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  # ── Build wheels: Linux (manylinux) ────────────────────────────────
+  # ── Build wheels: Linux (manylinux) ──────────────────────────────────────
   build-linux:
     name: Build • Linux (${{ matrix.target }})
     runs-on: ubuntu-latest
@@ -25,9 +31,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.11 3.12 3.13
           manylinux: auto
-          # Ensures the wheel is tagged manylinux_2_28 (broad compatibility)
           before-script-linux: |
-            # Installs OpenSSL headers inside the manylinux container if needed
             yum install -y openssl-devel || true
 
       - uses: actions/upload-artifact@v4
@@ -36,7 +40,7 @@ jobs:
           path: dist/*.whl
           if-no-files-found: error
 
-  # ── Build wheels: Windows ──────────────────────────────────────────
+  # ── Build wheels: Windows ─────────────────────────────────────────────────
   build-windows:
     name: Build • Windows (x86_64)
     runs-on: windows-latest
@@ -45,6 +49,7 @@ jobs:
 
       - uses: PyO3/maturin-action@v1
         with:
+          target: x86_64
           args: --release --out dist --interpreter 3.11 3.12 3.13
 
       - uses: actions/upload-artifact@v4
@@ -53,7 +58,7 @@ jobs:
           path: dist/*.whl
           if-no-files-found: error
 
-  # ── Build wheels: macOS (Intel + Apple Silicon) ────────────────────
+  # ── Build wheels: macOS (Intel + Apple Silicon) ───────────────────────────
   build-macos:
     name: Build • macOS (${{ matrix.target }})
     runs-on: macos-latest
@@ -75,7 +80,7 @@ jobs:
           path: dist/*.whl
           if-no-files-found: error
 
-  # ── Build source distribution (sdist) ─────────────────────────────
+  # ── Build source distribution (sdist) ────────────────────────────────────
   build-sdist:
     name: Build • sdist
     runs-on: ubuntu-latest
@@ -93,14 +98,45 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
-  # ── Publish to PyPI (Trusted Publisher — no tokens needed) ─────────
+  # ── Publish to TestPyPI (tags v*rc*) ─────────────────────────────────────
+  publish-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-windows, build-macos, build-sdist]
+    # Solo se ejecuta con tags de release candidate: v0.1.0rc1, v0.2.0rc2, etc.
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc')
+    environment: testpypi
+    permissions:
+      id-token: write   # Requerido para OIDC (Trusted Publisher)
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: List artifacts to publish
+        run: ls -lh dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # Sin username ni password — TestPyPI autentica via OIDC (Trusted Publisher).
+          # Configura el Trusted Publisher en: https://test.pypi.org/manage/account/publishing/
+
+  # ── Publish to PyPI prod (tags v* sin rc) ────────────────────────────────
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [build-linux, build-windows, build-macos, build-sdist]
-    environment: pypi          # GitHub Environment con proteccion de rama
+    # Solo se ejecuta con tags de release estable: v0.1.0, v1.0.0, etc.
+    # Excluye explícitamente los tags de release candidate (rc).
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')
+    environment: pypi
     permissions:
-      id-token: write          # OIDC — requerido por Trusted Publisher
+      id-token: write   # Requerido para OIDC (Trusted Publisher)
 
     steps:
       - uses: actions/download-artifact@v4
@@ -114,5 +150,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        # Sin username ni password. PyPI autentica via OIDC (Trusted Publisher).
+        # Sin username ni password — PyPI autentica via OIDC (Trusted Publisher).
         # Configura el Trusted Publisher en: https://pypi.org/manage/account/publishing/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -45,7 +45,7 @@ jobs:
     name: Build • Windows (x86_64)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -67,7 +67,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -85,7 +85,7 @@ jobs:
     name: Build • sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -45,7 +45,7 @@ jobs:
     name: Build • Windows (x86_64)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -67,7 +67,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -85,7 +85,7 @@ jobs:
     name: Build • sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 name: Release to PyPI
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Disparadores:
-#   • v*rc*  → publica en TestPyPI  (ej: v0.1.0rc1, v0.2.0rc2)
-#   • v*     → publica en PyPI prod (ej: v0.1.0, v1.0.0)
-#             (los tags rc* quedan excluidos por la condición del job publish)
+# Estrategia de ramas y tags:
+#
+#   develop → tag v*rc*  → TestPyPI   (release candidates, ej: v1.0.0rc1)
+#   main    → tag v*     → PyPI prod  (releases estables,  ej: v1.0.0)
+#
+# El job publish-testpypi verifica en runtime que el tag proviene de develop.
+# El job publish       verifica en runtime que el tag proviene de main.
+# Esto evita publicaciones accidentales cruzadas.
 # ─────────────────────────────────────────────────────────────────────────────
 on:
   push:
@@ -15,6 +19,32 @@ permissions:
   contents: read
 
 jobs:
+  # ── Validar origen del tag ────────────────────────────────────────────────
+  # Determina desde qué rama se creó el tag y expone ese valor a los demás jobs.
+  check-branch:
+    name: Check tag origin branch
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.get-branch.outputs.branch }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # necesario para ver el historial completo de ramas
+
+      - name: Detect branch containing this tag
+        id: get-branch
+        run: |
+          # Busca en qué rama remota existe el commit del tag
+          TAG_COMMIT=$(git rev-list -n 1 "$GITHUB_REF_NAME")
+          # Prioriza 'main' y 'develop' antes de otras ramas
+          BRANCH=$(git branch -r --contains "$TAG_COMMIT" \
+            | sed 's|origin/||' \
+            | sed 's/^[[:space:]]*//' \
+            | grep -E '^(main|develop)$' \
+            | head -1)
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Tag '$GITHUB_REF_NAME' found on branch: '${BRANCH}'"
+
   # ── Build wheels: Linux (manylinux) ──────────────────────────────────────
   build-linux:
     name: Build • Linux (${{ matrix.target }})
@@ -98,13 +128,17 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
-  # ── Publish to TestPyPI (tags v*rc*) ─────────────────────────────────────
+  # ── Publish to TestPyPI (tags v*rc* desde develop) ───────────────────────
   publish-testpypi:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
-    needs: [build-linux, build-windows, build-macos, build-sdist]
-    # Solo se ejecuta con tags de release candidate: v0.1.0rc1, v0.2.0rc2, etc.
-    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'rc')
+    needs: [check-branch, build-linux, build-windows, build-macos, build-sdist]
+    # Condiciones:
+    #   1. El tag debe contener 'rc' (release candidate)
+    #   2. El tag debe provenir de la rama 'develop'
+    if: |
+      contains(github.ref, 'rc') &&
+      needs.check-branch.outputs.branch == 'develop'
     environment: testpypi
     permissions:
       id-token: write   # Requerido para OIDC (Trusted Publisher)
@@ -123,17 +157,21 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          # Sin username ni password — TestPyPI autentica via OIDC (Trusted Publisher).
-          # Configura el Trusted Publisher en: https://test.pypi.org/manage/account/publishing/
+          # Autenticación via OIDC Trusted Publisher (sin usuario/contraseña).
+          # Configurar en: https://test.pypi.org/manage/account/publishing/
+          # Environment name: testpypi | Workflow: release.yml
 
-  # ── Publish to PyPI prod (tags v* sin rc) ────────────────────────────────
+  # ── Publish to PyPI prod (tags v* sin rc desde main) ─────────────────────
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [build-linux, build-windows, build-macos, build-sdist]
-    # Solo se ejecuta con tags de release estable: v0.1.0, v1.0.0, etc.
-    # Excluye explícitamente los tags de release candidate (rc).
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc')
+    needs: [check-branch, build-linux, build-windows, build-macos, build-sdist]
+    # Condiciones:
+    #   1. El tag NO debe contener 'rc' (release estable)
+    #   2. El tag debe provenir de la rama 'main'
+    if: |
+      !contains(github.ref, 'rc') &&
+      needs.check-branch.outputs.branch == 'main'
     environment: pypi
     permissions:
       id-token: write   # Requerido para OIDC (Trusted Publisher)
@@ -150,5 +188,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        # Sin username ni password — PyPI autentica via OIDC (Trusted Publisher).
-        # Configura el Trusted Publisher en: https://pypi.org/manage/account/publishing/
+        # Autenticación via OIDC Trusted Publisher (sin usuario/contraseña).
+        # Configurar en: https://pypi.org/manage/account/publishing/
+        # Environment name: pypi | Workflow: release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           before-script-linux: |
             yum install -y openssl-devel || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.target }}
           path: dist/*.whl
@@ -52,7 +52,7 @@ jobs:
           target: x86_64
           args: --release --out dist --interpreter 3.11 3.12 3.13
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-x86_64
           path: dist/*.whl
@@ -74,7 +74,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter 3.11 3.12 3.13
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.target }}
           path: dist/*.whl
@@ -92,7 +92,7 @@ jobs:
           command: sdist
           args: --out dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: dist/*.tar.gz
@@ -110,7 +110,7 @@ jobs:
       id-token: write   # Requerido para OIDC (Trusted Publisher)
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           merge-multiple: true
@@ -139,7 +139,7 @@ jobs:
       id-token: write   # Requerido para OIDC (Trusted Publisher)
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,3 +191,49 @@ jobs:
         # Autenticación via OIDC Trusted Publisher (sin usuario/contraseña).
         # Configurar en: https://pypi.org/manage/account/publishing/
         # Environment name: pypi | Workflow: release.yml
+
+  # ── Crear GitHub Release con notas del CHANGELOG ─────────────────────────
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [check-branch, publish]
+    # Solo se crea release en GitHub para tags estables (sin rc) desde main
+    if: |
+      !contains(github.ref, 'rc') &&
+      needs.check-branch.outputs.branch == 'main'
+    permissions:
+      contents: write   # Requerido para crear releases
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Extract CHANGELOG entry for this version
+        id: changelog
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}   # quita el prefijo 'v'
+          # Extrae el bloque del CHANGELOG entre este tag y el anterior
+          NOTES=$(awk "/^## \[${VERSION}\]/,/^## \[/" CHANGELOG.md \
+            | head -n -1 \
+            | tail -n +2)
+          # Exporta como variable multilinea para el siguiente step
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES"    >> "$GITHUB_OUTPUT"
+          echo "EOF"       >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "aegisq-pqc ${{ github.ref_name }}"
+          body: ${{ steps.changelog.outputs.notes }}
+          draft: false
+          prerelease: false
+          files: dist/*
+          fail_on_unmatched_files: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Build wheels: Linux (manylinux) ────────────────────────────────
+  build-linux:
+    name: Build • Linux (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --interpreter 3.11 3.12 3.13
+          manylinux: auto
+          # Ensures the wheel is tagged manylinux_2_28 (broad compatibility)
+          before-script-linux: |
+            # Installs OpenSSL headers inside the manylinux container if needed
+            yum install -y openssl-devel || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  # ── Build wheels: Windows ──────────────────────────────────────────
+  build-windows:
+    name: Build • Windows (x86_64)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist --interpreter 3.11 3.12 3.13
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-x86_64
+          path: dist/*.whl
+          if-no-files-found: error
+
+  # ── Build wheels: macOS (Intel + Apple Silicon) ────────────────────
+  build-macos:
+    name: Build • macOS (${{ matrix.target }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --interpreter 3.11 3.12 3.13
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  # ── Build source distribution (sdist) ─────────────────────────────
+  build-sdist:
+    name: Build • sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  # ── Publish to PyPI (Trusted Publisher — no tokens needed) ─────────
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-windows, build-macos, build-sdist]
+    environment: pypi          # GitHub Environment con proteccion de rama
+    permissions:
+      id-token: write          # OIDC — requerido por Trusted Publisher
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: List artifacts to publish
+        run: ls -lh dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Sin username ni password. PyPI autentica via OIDC (Trusted Publisher).
+        # Configura el Trusted Publisher en: https://pypi.org/manage/account/publishing/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Git
+.gitmessage
+
 # Python
 __pycache__/
 *.py[oc]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+Todos los cambios notables de este proyecto se documentan en este archivo.
+
+El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/),
+y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
+
+---
+
+## [Unreleased]
+
+---
+
+## [1.0.0] - 2026-04-11
+
+### Added
+- Implementación completa de ML-KEM (FIPS 203) en los tres niveles de seguridad:
+  - `ML_KEM_512`  (AES-128 equivalente)
+  - `ML_KEM_768`  (AES-192 equivalente) — nivel por defecto
+  - `ML_KEM_1024` (AES-256 equivalente)
+- `MlKem` — API de bajo nivel para operaciones KEM crudas (`generate_keypair`, `encapsulate`, `decapsulate`)
+- `AegisCipher` — API de alto nivel con cifrado híbrido ML-KEM + AES-256-GCM (FIPS 197)
+- `KeyPair` — Tipo que encapsula clave pública y secreta con zeroización automática al salir de scope (via `zeroize`)
+- `SecurityLevel` — Enum con los tres niveles FIPS 203: `ML_KEM_512`, `ML_KEM_768`, `ML_KEM_1024`
+- Jerarquía de excepciones Python con mapeo 1:1 a errores Rust:
+  - `AegisQError` (base)
+  - `DecapsulationError`
+  - `DecryptionError`
+  - `InvalidParameterError`
+  - `RngError`
+- Bindings Python/Rust via PyO3 0.28 con ABI estable (`abi3-py311`)
+- Soporte de wheels para Linux (x86_64, aarch64), Windows (x86_64) y macOS (x86_64, aarch64)
+- CI/CD con GitHub Actions: build multiplataforma + publicación OIDC a TestPyPI y PyPI
+- Vectores KAT (Known Answer Tests) de NIST para validación de correctitud
+- Tipado estático completo (`py.typed`, PEP 561)
+
+### Security
+- Implementación de `implicit rejection` (FIPS 203 §7.3) en decapsulación: ante un ciphertext
+  inválido se devuelve un shared secret derivado de material interno en lugar de lanzar error,
+  previniendo ataques de oráculo (CCA2)
+- Zeroización de material criptográfico sensible en memoria al liberar estructuras Rust
+- Sin dependencias de red en tiempo de ejecución
+
+---
+
+## Tipos de cambio
+
+| Tipo | Descripción |
+|---|---|
+| `Added` | Funcionalidades nuevas |
+| `Changed` | Cambios en funcionalidad existente |
+| `Deprecated` | Funcionalidad que será eliminada en versiones futuras |
+| `Removed` | Funcionalidad eliminada |
+| `Fixed` | Corrección de bugs |
+| `Security` | Correcciones de seguridad o cambios relevantes para la seguridad |
+
+[Unreleased]: https://github.com/AC-Santiago/AegisQ/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/AC-Santiago/AegisQ/releases/tag/v1.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Santiago Acosta Cespedes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,86 @@
+# Política de Seguridad
+
+## Versiones soportadas
+
+| Versión | Soporte de seguridad |
+|---|---|
+| 1.0.x | ✅ Activo |
+
+## Reporte de vulnerabilidades
+
+**Por favor, no reportes vulnerabilidades de seguridad como Issues públicos de GitHub.**
+
+AegisQ implementa primitivas criptográficas post-cuánticas. Un reporte público de una
+vulnerabilidad antes de que esté parcheada puede poner en riesgo a usuarios del paquete.
+
+### Cómo reportar
+
+Usa el canal de **reporte privado de vulnerabilidades** de GitHub:
+
+1. Ve a la pestaña [Security](https://github.com/AC-Santiago/AegisQ/security) del repositorio
+2. Haz clic en **"Report a vulnerability"**
+3. Completa el formulario con la mayor cantidad de detalle posible
+
+Recibirás una respuesta en un plazo máximo de **72 horas**.
+
+### Qué incluir en el reporte
+
+Para acelerar la evaluación, incluye:
+
+- **Descripción**: Descripción clara de la vulnerabilidad y su impacto potencial
+- **Componente afectado**: Módulo, clase o función específica (`MlKem`, `AegisCipher`, etc.)
+- **Pasos para reproducir**: Código mínimo que demuestre el problema
+- **Versión afectada**: Versión de `aegisq-pqc` donde se reproduce
+- **Impacto estimado**: Confidencialidad, integridad, disponibilidad
+- **Posible mitigación**: Si tienes sugerencias de cómo corregirlo
+
+### Proceso de respuesta
+
+```
+Reporte recibido → Confirmación (≤72h) → Evaluación (≤7 días) → Parche + CVE → Disclosure público
+```
+
+1. **Confirmación** (≤ 72 horas): Acuse de recibo y asignación de severidad preliminar
+2. **Evaluación** (≤ 7 días): Reproducción, análisis de impacto y plan de mitigación
+3. **Parche**: Desarrollo y revisión del fix, coordinar embargo con el reportador
+4. **CVE**: Solicitud de CVE si aplica
+5. **Disclosure**: Publicación coordinada del advisory y release del parche
+
+### Reconocimiento
+
+Los investigadores que reporten vulnerabilidades válidas serán reconocidos en el
+`CHANGELOG.md` de la versión que incluya el parche, salvo que prefieran permanecer anónimos.
+
+---
+
+## Consideraciones de seguridad del diseño
+
+### Qué protege AegisQ
+
+- **Confidencialidad** del shared secret y del payload cifrado
+- **Autenticidad** del ciphertext via AES-256-GCM (tag de 128 bits)
+- **Resistencia post-cuántica** del intercambio de claves (ML-KEM, FIPS 203)
+
+### Qué NO protege AegisQ
+
+- **Gestión de claves a largo plazo**: AegisQ no almacena ni gestiona claves persistentes.
+  La seguridad de las claves generadas depende de cómo el usuario las almacene.
+- **Anonimato o privacidad de metadatos**: AegisQ no oculta quién se comunica con quién.
+- **Autenticación de identidad**: ML-KEM es un KEM, no un esquema de firma.
+  Para autenticación de origen usa un esquema de firma post-cuántica (ej: ML-DSA / FIPS 204).
+
+### Dependencias criptográficas (Rust)
+
+| Crate | Propósito | Auditoría |
+|---|---|---|
+| `ml-kem` (via sha3, aes-gcm) | ML-KEM FIPS 203 | RustCrypto — auditado |
+| `aes-gcm` | AES-256-GCM FIPS 197 | RustCrypto — auditado |
+| `zeroize` | Zeroización de memoria sensible | RustCrypto — auditado |
+| `rand_core` | CSPRNG del sistema operativo | RustCrypto — auditado |
+
+### Nivel de madurez
+
+AegisQ es un proyecto en estado **Alpha (v1.0.0)**. Aunque implementa los estándares FIPS
+correctamente y los vectores KAT de NIST pasan, **no ha sido sometido a una auditoría de
+seguridad independiente**. No se recomienda su uso en sistemas productivos críticos sin
+una auditoría previa.

--- a/aegisq/__init__.py
+++ b/aegisq/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
     "RngError",
 ]
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"

--- a/aegisq/__init__.py
+++ b/aegisq/__init__.py
@@ -45,4 +45,9 @@ __all__ = [
     "RngError",
 ]
 
-__version__ = "1.0.0"
+from importlib.metadata import version as _version
+
+try:
+    __version__ = _version("aegisq-pqc")
+except Exception:  # paquete no instalado (ej: desarrollo local con maturin develop)
+    __version__ = "unknown"

--- a/crates/aegisq-core/Cargo.toml
+++ b/crates/aegisq-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "aegisq-core"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/aegisq-pyo3/Cargo.toml
+++ b/crates/aegisq-pyo3/Cargo.toml
@@ -9,7 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # abi3-py311: genera un único wheel ABI3 compatible con Python 3.11+
-# (coincide con requires-python = ">=3.11" en pyproject.toml).
-# Reduce el número de wheels necesarios al mínimo sin sacrificar compatibilidad.
 pyo3        = { version = "0.28", features = ["extension-module", "abi3-py311"] }
 aegisq-core = { path = "../aegisq-core" }

--- a/crates/aegisq-pyo3/Cargo.toml
+++ b/crates/aegisq-pyo3/Cargo.toml
@@ -8,5 +8,8 @@ name       = "_aegisq_core"
 crate-type = ["cdylib"]
 
 [dependencies]
+# abi3-py311: genera un único wheel ABI3 compatible con Python 3.11+
+# (coincide con requires-python = ">=3.11" en pyproject.toml).
+# Reduce el número de wheels necesarios al mínimo sin sacrificar compatibilidad.
 pyo3        = { version = "0.28", features = ["extension-module", "abi3-py311"] }
 aegisq-core = { path = "../aegisq-core" }

--- a/crates/aegisq-pyo3/Cargo.toml
+++ b/crates/aegisq-pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "aegisq-pyo3"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [project]
-<<<<<<< HEAD
 name = "aegisq-pqc"
 version = "1.0.0"
 description = "Post-quantum cryptography engine — Hybrid ML-KEM + AES-256-GCM (FIPS 203)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aegisq"
+name = "aegisq-pqc"
 version = "0.1.0"
 description = "Post-quantum cryptography engine — Hybrid ML-KEM + AES-256-GCM (FIPS 203)"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [project]
+<<<<<<< HEAD
 name = "aegisq-pqc"
-version = "0.1.0"
+version = "1.0.0"
 description = "Post-quantum cryptography engine — Hybrid ML-KEM + AES-256-GCM (FIPS 203)"
 readme = "README.md"
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 authors = [
     { name = "AC-Santiago", email = "acostasantiago311124578@gmail.com" }
 ]
@@ -39,7 +40,7 @@ classifiers = [
 
 [project.urls]
 Homepage   = "https://github.com/AC-Santiago/AegisQ"
-Repository = "https://github.com/AC-Santiago/AegisQ"
+Repository = "https://github.com/AC-Santiago/AegisQ.git"
 Issues     = "https://github.com/AC-Santiago/AegisQ/issues"
 
 [tool.maturin]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,46 @@
 [project]
 name = "aegisq"
 version = "0.1.0"
-description = "Post-quantum cryptography engine — Hybrid ML-KEM + AES-256-GCM"
+description = "Post-quantum cryptography engine — Hybrid ML-KEM + AES-256-GCM (FIPS 203)"
 readme = "README.md"
+license = { text = "MIT" }
 authors = [
     { name = "AC-Santiago", email = "acostasantiago311124578@gmail.com" }
 ]
 requires-python = ">=3.11"
 dependencies = []
+keywords = [
+    "post-quantum",
+    "cryptography",
+    "ml-kem",
+    "kyber",
+    "pqc",
+    "fips-203",
+    "key-encapsulation",
+    "lattice-cryptography",
+    "aes-gcm",
+    "rust",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Topic :: Security :: Cryptography",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+    "Operating System :: OS Independent",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage   = "https://github.com/AC-Santiago/AegisQ"
+Repository = "https://github.com/AC-Santiago/AegisQ"
+Issues     = "https://github.com/AC-Santiago/AegisQ/issues"
 
 [tool.maturin]
 manifest-path = "crates/aegisq-pyo3/Cargo.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aegisq"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Sincroniza `develop` con el estado actual de `main`.

## Commits incluidos
- `f0be7f9` chore: apply best practices (CHANGELOG, SECURITY, dependabot, __version__ dinámico, github-release job)
- `17dabec` fix: bump __version__ 1.0.0 + branch-based publish gates
- `725faa9` fix(pyproject): remove leftover merge conflict marker
- `18353ed` chore: sync Rust crates version to 1.0.0
- `890ef3f` fix(pyproject): resolve merge conflict
- `d13e28b` chore: rename PyPI distribution to aegisq-pqc
- `8f5d5ae` ci(release): bump artifact actions to latest major versions
- `fa6f314` ci(release): bump actions/checkout v6
- `c80f65a` ci(release): bump actions/checkout v5
- `7dabf19` build(pyo3): abi3-py311 ABI stable wheel

Y los del PR #5 (build(deps): merge Dependabot PRs #1-#4)