### PR TITLE
fix(ci): reemplazar actions-rust-lang/audit@v1 por cargo audit directo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,11 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
-      - name: Set up Python for audit
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
 
       - name: Audit dependencies
-        uses: actions-rust-lang/audit@v1
+        run: cargo audit
 
   # ── Job 2: Python — build, test, lint ──────────────────────────────
   test-python:


### PR DESCRIPTION
## Fix: CI audit step falla por dependencia Python faltante

### Problema

El action `actions-rust-lang/audit@v1` falla en el CI con:

```
ModuleNotFoundError: No module named 'requests'
Traceback (most recent call last):
  File "/home/runner/work/_actions/actions-rust-lang/audit/v1/audit.py", line 8, in <module>
    import requests
```

El action importa el módulo Python `requests` sin declararlo como dependencia, por lo que
los runners de GitHub Actions (que solo tienen los módulos estándar) no pueden ejecutarlo.

Detectado durante el CI del PR #30 (release v1.2.0), run 26994994505 — el job
`Rust (ubuntu-latest)` falló en el audit step.

### Solución

Reemplazar el action por la herramienta oficial `cargo audit` instalada vía
`cargo install`:

```diff
-      - name: Set up Python for audit
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Audit dependencies
-        uses: actions-rust-lang/audit@v1
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+
+      - name: Audit dependencies
+        run: cargo audit
```

### Por qué

- `cargo audit` es la herramienta oficial de RustSec para auditar vulnerabilidades
- No tiene dependencias externas (todo es un binario Rust)
- Es la forma estándar recomendada por la comunidad
- Funciona identicamente en ubuntu y macOS

### Verificación

Este fix desbloquea el CI del release PR #30. La validación previa de la suite
de tests (cargo test 159/159, pytest 132/132) ya pasó localmente; este fix solo
resuelve el paso de auditoría.

### Cambio

| Archivo | Cambio |
|---------|--------|
| `.github/workflows/ci.yml` | Reemplaza action por cargo install + cargo audit |

Refs: PR #30 (release v1.2.0)