### PR TITLE
fix(develop): align residual differences with main after sync #32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: cargo install --locked cargo-audit
 
       - name: Audit dependencies
-        uses: actions-rust-lang/audit@v1
+        run: cargo audit
 
   # ── Job 2: Python — build, test, lint ──────────────────────────────
   test-python:

--- a/aegisq/kem.py
+++ b/aegisq/kem.py
@@ -21,8 +21,6 @@ Ejemplo::
 
 from __future__ import annotations
 
-from typing import Optional
-
 from aegisq._aegisq_core import (
     KeyPair,
     SecurityLevel,


### PR DESCRIPTION
## Fix residual diff after sync PR #32

The sync PR #32 left two minor residual differences in `develop` that do not match `main`, caused by GitHub's automatic pre-merge re-sync of the PR's base branch (which merged the old `develop` history back into the sync branch).

### Changes (4 lines across 2 files)

**1. `aegisq/kem.py`** — remove unused `from typing import Optional` (2 lines)
   The `Optional[SecurityLevel]` syntax was replaced with `SecurityLevel | None` (Python 3.10+ union syntax) when the lint fix landed in `main`, making the import dead. The pre-merge auto-merge reintroduced it.

**2. `.github/workflows/ci.yml`** — restore `run: cargo audit` (1 line)
   The `Audit dependencies` step was switched from `actions-rust-lang/audit@v1` → `cargo audit` in PR #31 and merged to main. The pre-merge auto-merge reverted it.

### Diff against `origin/develop`

```
.github/workflows/ci.yml | 2 +-
aegisq/kem.py            | 2 --
2 files changed, 1 insertion(+), 3 deletions(-)
```

### Note on PR diff display

Due to the persistent SHA divergence between `origin/develop` and the local `develop` history, GitHub's PR diff stat may inflate the visual diff (showing many files / many additions). The actual content diff is exactly the 4 lines above — verified locally with `git diff origin/develop`.

**Recommendation: Squash and merge** to collapse everything into a single clean commit on develop.