### PR TITLE
fix(pyo3): remove unused direct base64 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,6 @@ name = "aegisq-pyo3"
 version = "1.2.0"
 dependencies = [
  "aegisq-core",
- "base64",
  "pyo3",
 ]
 

--- a/crates/aegisq-pyo3/Cargo.toml
+++ b/crates/aegisq-pyo3/Cargo.toml
@@ -13,4 +13,3 @@ crate-type = ["cdylib"]
 # abi3-py311: genera un único wheel ABI3 compatible con Python 3.11+
 pyo3        = { version = "0.28", features = ["extension-module", "abi3-py311"] }
 aegisq-core = { path = "../aegisq-core" }
-base64      = { workspace = true }


### PR DESCRIPTION
Removes an unused direct base64 dependency from aegisq-pyo3/Cargo.toml. The base64 crate is already a transitive dependency through aegisq-core. Verified no direct usage in crates/aegisq-pyo3/src/. Suggested by Copilot code review.

Cargo.lock is updated to reflect the removed direct dependency (the base64 crate itself remains in the lock because aegisq-core still uses it).