### PR TITLE
feat(v1.3.0): key serialization (PEM/JSON/encrypted blob) + cargo-deny gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,6 +546,8 @@ Cada fase debe tener sus tests pasando antes de avanzar a la siguiente.
 | 27b  | `tests/python/test_kat_vectors.py`       | Tests de verificación con KAT vectors                | ✅ Completo |
 | 28   | `aegisq/session.py`                      | EphemeralSession con forward secrecy                | ✅ Completo |
 | 29   | `aegisq/cipher.py` + `test_cipher_async.py` | Soporte async (encrypt_async/decrypt_async)       | ✅ Completo |
+| 30   | `crates/aegisq-core/src/kdf.rs` + `key_wrap.rs` + `kem.rs` (validate_*) | HKDF/HMAC-SHA3-256 + cifrado de secret_key (v1.3.0) | ✅ v1.3.0 |
+| 31   | `crates/aegisq-pyo3/src/types.rs` + `key_io_bindings.rs` + `aegisq/keys.py` + `deny.toml` | Serializacion PEM/JSON/encrypted + cargo-deny gate (v1.3.0) | ✅ v1.3.0 |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ---
 
+## [1.3.0] - 2026-06-26
+
+### Added
+- **Serializacion de llaves** — Exportar/importar llaves en formatos estandar:
+  - Llave publica: PEM-like (`-----BEGIN ML-KEM PUBLIC KEY-----`) y JSON
+    (con campos `algorithm`/`level`/`public_key`).
+  - Llave privada: blob binario cifrado con contrasena, opcionalmente envuelto en
+    PEM ENCRYPTED (`-----BEGIN ENCRYPTED ML-KEM PRIVATE KEY-----`).
+- **Cifrado de llaves secretas**: AES-256-GCM con clave derivada via HKDF-SHA3-256
+  (HMAC-SHA3-256 manual, block size 136 bytes per NIST SP 800-185).
+- **Modulo `aegisq.keys`** — API de alto nivel para persistencia:
+  `save_public_key`, `load_public_key`, `save_secret_key`, `load_secret_key`,
+  `public_key_to_pem/json`, `secret_key_to_pem`.
+- **Excepcion `KeySerializationError`** — Para PEM/JSON/blob malformados.
+- **Tests pytest**: 19 nuevos tests en `tests/python/test_key_serialization.py`
+  cubriendo roundtrip en los 3 niveles, deteccion de formato, errores de
+  parsing, y verificacion critica de seguridad (secret_key raw NO aparece en PEM).
+- **`deny.toml`** — Configuracion de `cargo-deny` (gate de licencias, bans,
+  sources, advisories en CI).
+
+### Changed
+- **`pyo3` 0.28.3 → 0.29.0** — Fix de RUSTSEC-2026-0177 (missing `Sync` bound
+  en `PyCFunction::new_closure`).
+- **`aegisq-pyo3` agrega `getrandom` y `base64` como deps directas** —
+  necesarias para generar salt/nonce (Capa 2) y codificar Base64 STANDARD
+  (formato PEM).
+
+### Security
+- **Llaves secretas NUNCA se exportan en texto plano** — siempre cifradas
+  con AES-256-GCM (clave derivada via HKDF-SHA3-256).
+- **HMAC-SHA3-256 implementado manualmente** — block size correcto = 136 bytes
+  (rate del sponge Keccak), verificado contra Python `hashlib.sha3_256` stdlib.
+- **Wrong password en `unwrap_secret_key`** retorna `DecryptionFailed`
+  (indistinguible de blob corrupto — anti side-channel).
+- **`cargo-deny` como gate en CI** — bloquea licenses no aprobadas (GPL/LGPL/AGPL),
+  crates prohibidos (`ring`, `openssl`, `openssl-sys`), y sources fuera de crates.io.
+
+---
+
 ## [1.2.0] - 2026-05-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -366,18 +366,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -397,13 +397,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,8 @@ name = "aegisq-pyo3"
 version = "1.2.0"
 dependencies = [
  "aegisq-core",
+ "base64",
+ "getrandom",
  "pyo3",
 ]
 

--- a/aegisq/__init__.py
+++ b/aegisq/__init__.py
@@ -29,10 +29,20 @@ from aegisq.exceptions import (
     DecapsulationError,
     DecryptionError,
     InvalidParameterError,
+    KeySerializationError,
     RngError,
     SessionExpiredError,
 )
 from aegisq.kem import MlKem
+from aegisq.keys import (
+    load_public_key,
+    load_secret_key,
+    public_key_to_json,
+    public_key_to_pem,
+    save_public_key,
+    save_secret_key,
+    secret_key_to_pem,
+)
 from aegisq.session import EphemeralSession
 
 __all__ = [
@@ -45,8 +55,16 @@ __all__ = [
     "DecapsulationError",
     "DecryptionError",
     "InvalidParameterError",
+    "KeySerializationError",
     "RngError",
     "SessionExpiredError",
+    "load_public_key",
+    "load_secret_key",
+    "public_key_to_json",
+    "public_key_to_pem",
+    "save_public_key",
+    "save_secret_key",
+    "secret_key_to_pem",
 ]
 
 from importlib.metadata import PackageNotFoundError

--- a/aegisq/_aegisq_core.pyi
+++ b/aegisq/_aegisq_core.pyi
@@ -26,6 +26,11 @@ class InvalidParameterError(AegisQError, ValueError):
 
     ...
 
+class KeySerializationError(AegisQError):
+    """Invalid key serialization format (PEM header, JSON, magic bytes)."""
+
+    ...
+
 class RngError(AegisQError):
     """CSPRNG not available from the operating system."""
 
@@ -62,6 +67,26 @@ class KeyPair:
 
     def public_key_b64(self) -> str:
         """Retorna la clave publica como Base64 URL-safe sin padding."""
+        ...
+
+    def public_key_pem(self) -> str:
+        """Retorna la clave publica en formato PEM-like ML-KEM."""
+        ...
+
+    def public_key_json(self) -> str:
+        """Retorna la clave publica en formato JSON."""
+        ...
+
+    def export_secret_key_raw(self, password: bytes) -> bytes:
+        """Retorna la clave secreta cifrada como blob binario opaco.
+
+        Usa AES-256-GCM con clave derivada de ``password`` via HKDF-SHA3-256.
+        Libera el GIL durante HKDF + AES-GCM.
+        """
+        ...
+
+    def export_secret_key_pem(self, password: bytes) -> str:
+        """Retorna la clave secreta cifrada en formato PEM-like ENCRYPTED."""
         ...
 
 # --- Funciones KEM ---
@@ -160,4 +185,56 @@ def decrypt_hybrid(
     level: SecurityLevel = SecurityLevel.ML_KEM_768,
 ) -> bytes:
     """Descifra un Transit Package."""
+    ...
+
+# --- Serializacion / carga de llaves (v1.3.0) ---
+
+def load_public_key_pem(
+    pem: str,
+    level: SecurityLevel = SecurityLevel.ML_KEM_768,
+) -> bytes:
+    """Carga una llave publica desde formato PEM-like ML-KEM.
+
+    Raises:
+        KeySerializationError: Si el PEM no tiene header/footer o Base64 invalido.
+        InvalidParameterError: Si el tamano no coincide con el nivel.
+    """
+    ...
+
+def load_public_key_json(json: str) -> tuple[bytes, SecurityLevel]:
+    """Carga una llave publica desde JSON.
+
+    El JSON debe tener los campos ``algorithm``, ``level`` y ``public_key``.
+
+    Returns:
+        Tupla ``(public_key_bytes, level)``.
+
+    Raises:
+        KeySerializationError: Si el JSON esta malformado o le faltan campos.
+        InvalidParameterError: Si el tamano no coincide con el nivel declarado.
+    """
+    ...
+
+def load_secret_key_raw(
+    blob: bytes,
+    password: bytes,
+) -> tuple[bytes, SecurityLevel]:
+    """Descifra y retorna la llave secreta desde un blob binario.
+
+    Raises:
+        DecryptionError: Si la contrasena es incorrecta o el blob esta corrupto.
+        KeySerializationError: Si magic/version son invalidos o el blob esta truncado.
+    """
+    ...
+
+def load_secret_key_pem(
+    pem: str,
+    password: bytes,
+) -> tuple[bytes, SecurityLevel]:
+    """Descifra y retorna la llave secreta desde un PEM-like ENCRYPTED.
+
+    Raises:
+        DecryptionError: Si la contrasena es incorrecta o el blob esta corrupto.
+        KeySerializationError: Si el PEM/Base64/magic son invalidos.
+    """
     ...

--- a/aegisq/exceptions.py
+++ b/aegisq/exceptions.py
@@ -18,6 +18,7 @@ from aegisq._aegisq_core import (
     DecapsulationError,
     DecryptionError,
     InvalidParameterError,
+    KeySerializationError,
     RngError,
 )
 
@@ -26,6 +27,7 @@ __all__ = [
     "DecapsulationError",
     "DecryptionError",
     "InvalidParameterError",
+    "KeySerializationError",
     "RngError",
     "SessionExpiredError",
 ]

--- a/aegisq/keys.py
+++ b/aegisq/keys.py
@@ -1,0 +1,212 @@
+"""Utilidades de serializacion y persistencia de llaves ML-KEM (v1.3.0).
+
+Provee helpers de alto nivel para exportar/importar llaves desde/hacia
+disco, variables de entorno y bytes en memoria.
+
+La llave privada **nunca** se exporta en texto plano: se cifra con
+AES-256-GCM usando una clave derivada de una contrasena via HKDF-SHA3-256.
+
+Formatos soportados:
+
+* **Llave publica** — PEM-like ``-----BEGIN ML-KEM PUBLIC KEY-----`` (default)
+  o JSON con campos ``algorithm``/``level``/``public_key``.
+* **Llave privada** — PEM-like ``-----BEGIN ENCRYPTED ML-KEM PRIVATE KEY-----``
+  con blob binario cifrado (Base64 STANDARD en el cuerpo).
+
+Ejemplo basico::
+
+    from aegisq import AegisCipher, SecurityLevel
+    from aegisq.keys import save_public_key, load_public_key, save_secret_key, load_secret_key
+
+    cipher = AegisCipher()
+    keypair = cipher.generate_keypair()
+
+    # Guardar en disco
+    save_public_key(keypair, "recipient.pem")
+    save_secret_key(keypair, "private.key", password=b"s3cr3t")
+
+    # Cargar desde disco
+    pub_key = load_public_key("recipient.pem")
+    sec_key = load_secret_key("private.key", password=b"s3cr3t")
+
+    # Usar
+    package = cipher.encrypt(b"datos secretos", pub_key)
+    plaintext = cipher.decrypt(package, sec_key)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from aegisq._aegisq_core import (
+    KeyPair,
+    SecurityLevel,
+    load_public_key_json,
+    load_public_key_pem,
+    load_secret_key_pem,
+)
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = [
+    "save_public_key",
+    "load_public_key",
+    "save_secret_key",
+    "load_secret_key",
+    "public_key_to_pem",
+    "public_key_to_json",
+    "secret_key_to_pem",
+]
+
+
+def save_public_key(
+    keypair: KeyPair,
+    path: str | Path,
+    *,
+    fmt: str = "pem",
+) -> None:
+    """Guarda la llave publica en disco.
+
+    Args:
+        keypair: El ``KeyPair`` del cual exportar la llave publica.
+        path: Ruta del archivo destino. Se recomienda extension ``.pem``
+              para PEM o ``.json`` para JSON.
+        fmt: Formato de salida. ``"pem"`` (default) o ``"json"``.
+
+    Raises:
+        ValueError: Si ``fmt`` no es ``"pem"`` ni ``"json"``.
+        OSError: Si no se puede escribir el archivo.
+    """
+    if fmt == "pem":
+        content = keypair.public_key_pem()
+    elif fmt == "json":
+        content = keypair.public_key_json()
+    else:
+        raise ValueError(f"fmt must be 'pem' or 'json', got {fmt!r}")
+    Path(path).write_text(content, encoding="utf-8")
+
+
+def load_public_key(
+    path: str | Path,
+    *,
+    level: SecurityLevel | None = None,
+) -> bytes:
+    """Carga una llave publica desde disco.
+
+    Detecta automaticamente el formato (PEM o JSON) por la primera linea
+    del archivo. Si es JSON, el nivel se extrae del campo ``"level"`` y
+    el parametro ``level`` es ignorado.
+
+    Args:
+        path: Ruta del archivo.
+        level: Nivel de seguridad ML-KEM esperado. **Obligatorio** para
+               archivos PEM (no se puede inferir del contenido). Para
+               JSON se ignora y se usa el campo ``"level"``.
+
+    Returns:
+        bytes: La llave publica lista para pasar a ``AegisCipher.encrypt()``.
+
+    Raises:
+        ValueError: Si el formato del archivo no es reconocible o si
+                    ``level`` no se proporciono para un PEM.
+        KeySerializationError: Si el PEM/JSON esta malformado.
+        InvalidParameterError: Si el tamano no coincide con el nivel.
+        OSError: Si no se puede leer el archivo.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    # Detectar formato por la primera linea no vacia.
+    first_line = next(
+        (ln for ln in text.splitlines() if ln.strip()),
+        "",
+    )
+    if first_line.startswith("-----BEGIN ML-KEM PUBLIC KEY-----"):
+        if level is None:
+            raise ValueError(
+                "level es obligatorio para cargar archivos PEM "
+                "(no se puede inferir del contenido)"
+            )
+        return load_public_key_pem(text, level)
+    if first_line.startswith("{"):
+        pk_bytes, _ = load_public_key_json(text)
+        return pk_bytes
+    raise ValueError(
+        f"Formato de archivo no reconocible: primera linea = {first_line!r}"
+    )
+
+
+def save_secret_key(
+    keypair: KeyPair,
+    path: str | Path,
+    *,
+    password: bytes,
+) -> None:
+    """Cifra y guarda la llave privada en disco en formato PEM ENCRYPTED.
+
+    La llave **NUNCA** se escribe en texto plano: se cifra con
+    AES-256-GCM + HKDF-SHA3-256(``password``).
+
+    Args:
+        keypair: El ``KeyPair`` del cual exportar la llave privada.
+        path: Ruta del archivo destino. Se recomienda extension ``.key``.
+        password: Contrasena para derivar la clave de cifrado.
+
+    Raises:
+        RngError: Si el CSPRNG del OS no esta disponible.
+        OSError: Si no se puede escribir el archivo.
+    """
+    content = keypair.export_secret_key_pem(password)
+    Path(path).write_text(content, encoding="utf-8")
+
+
+def load_secret_key(
+    path: str | Path,
+    *,
+    password: bytes,
+) -> bytes:
+    """Descifra y carga la llave privada desde disco.
+
+    Args:
+        path: Ruta del archivo PEM ENCRYPTED.
+        password: Contrasena usada al guardar.
+
+    Returns:
+        bytes: La llave secreta lista para pasar a
+               ``MlKem.decapsulate()`` o ``AegisCipher.decrypt()``.
+
+    Raises:
+        DecryptionError: Si la contrasena es incorrecta o el archivo esta corrupto.
+        KeySerializationError: Si el PEM/Base64/magic son invalidos.
+        OSError: Si no se puede leer el archivo.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    sk_bytes, _ = load_secret_key_pem(text, password)
+    return sk_bytes
+
+
+def public_key_to_pem(keypair: KeyPair) -> str:
+    """Convierte la llave publica de un ``KeyPair`` a formato PEM-like ML-KEM.
+
+    Equivalente a ``keypair.public_key_pem()``, expuesto aqui para
+    conveniencia de import.
+    """
+    return keypair.public_key_pem()
+
+
+def public_key_to_json(keypair: KeyPair) -> str:
+    """Convierte la llave publica de un ``KeyPair`` a formato JSON.
+
+    Equivalente a ``keypair.public_key_json()``, expuesto aqui para
+    conveniencia de import.
+    """
+    return keypair.public_key_json()
+
+
+def secret_key_to_pem(keypair: KeyPair, *, password: bytes) -> str:
+    """Exporta la llave privada cifrada como string PEM ENCRYPTED.
+
+    Equivalente a ``keypair.export_secret_key_pem(password)``, expuesto
+    aqui para conveniencia de import.
+    """
+    return keypair.export_secret_key_pem(password)

--- a/crates/aegisq-core/Cargo.toml
+++ b/crates/aegisq-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "aegisq-core"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/aegisq-core/src/error.rs
+++ b/crates/aegisq-core/src/error.rs
@@ -24,6 +24,9 @@ pub enum AegisQError {
     ///
     /// Se produce cuando el string provisto no es Base64 URL-safe valido.
     Base64DecodeError(&'static str),
+
+    /// Error al parsear o serializar el formato de llave (PEM header, JSON, magic bytes).
+    KeySerializationError(&'static str),
 }
 
 impl core::fmt::Display for AegisQError {
@@ -36,6 +39,7 @@ impl core::fmt::Display for AegisQError {
                 write!(f, "AES-GCM authentication tag verification failed")
             }
             AegisQError::Base64DecodeError(msg) => write!(f, "base64 decode error: {}", msg),
+            AegisQError::KeySerializationError(msg) => write!(f, "key serialization error: {}", msg),
         }
     }
 }

--- a/crates/aegisq-core/src/kdf.rs
+++ b/crates/aegisq-core/src/kdf.rs
@@ -1,0 +1,186 @@
+//! HKDF-SHA3-256 + HMAC-SHA3-256 manual implementation.
+//!
+//! Implementa HMAC y HKDF con SHA3-256 segun RFC 5869 y NIST SP 800-185,
+//! usando solo el crate `sha3` (ya en el workspace). No agrega dependencias nuevas.
+//!
+//! **Block size para HMAC-SHA3-256 = 136 bytes (rate del sponge Keccak, 1088 bits).**
+//! Esto difiere de SHA-2 (SHA-256 usa block size 64 bytes). El spec original de v1.3.0
+//! decia "64-byte block size" — eso era un error. SHA3-256 es un sponge function,
+//! no Merkle-Damgard. El block size es la capacidad del sponge.
+//!
+//! Referencia: NIST SP 800-185 (SHA-3 Derived Functions).
+//!
+//! Este modulo es `pub(crate)` — nunca se expone en `lib.rs`. Solo lo usa `key_wrap.rs`.
+
+#![allow(dead_code)] // sera usado por key_wrap.rs en el mismo milestone
+
+use sha3::{Digest, Sha3_256};
+use zeroize::{Zeroize, Zeroizing};
+
+/// Block size para HMAC-SHA3-256 = rate del sponge = 136 bytes (1088 bits).
+/// NIST SP 800-185 §4.2.
+const SHA3_256_BLOCK_SIZE: usize = 136;
+
+/// HMAC-SHA3-256: implementacion manual con patron ipad/opad.
+///
+/// # Arguments
+/// - `key`: clave de cualquier longitud
+/// - `data`: datos a autenticar
+///
+/// # Returns
+/// 32 bytes de tag de autenticacion.
+pub(crate) fn hmac_sha3_256(key: &[u8], data: &[u8]) -> [u8; 32] {
+    // Step 1: normalizar la clave a B bytes (136).
+    // - Si key.len() > B: K' = Hash(key) padded to B.
+    // - Si key.len() <= B: K' = key || zeros to B.
+    let mut key_block = [0u8; SHA3_256_BLOCK_SIZE];
+    if key.len() > SHA3_256_BLOCK_SIZE {
+        let hashed = Sha3_256::digest(key);
+        key_block[..32].copy_from_slice(&hashed);
+        // resto ya esta en zeros
+    } else {
+        key_block[..key.len()].copy_from_slice(key);
+    }
+
+    // Step 2: construir ipad y opad (K' XOR constantes, ambos de B bytes)
+    let mut ipad = [0x36u8; SHA3_256_BLOCK_SIZE];
+    let mut opad = [0x5Cu8; SHA3_256_BLOCK_SIZE];
+    for i in 0..SHA3_256_BLOCK_SIZE {
+        ipad[i] ^= key_block[i];
+        opad[i] ^= key_block[i];
+    }
+
+    // Step 3: inner hash = SHA3-256(ipad || data)
+    let mut inner_hasher = Sha3_256::new();
+    Digest::update(&mut inner_hasher, ipad);
+    Digest::update(&mut inner_hasher, data);
+    let inner = inner_hasher.finalize();
+
+    // Step 4: outer hash = SHA3-256(opad || inner)
+    let mut outer_hasher = Sha3_256::new();
+    Digest::update(&mut outer_hasher, opad);
+    Digest::update(&mut outer_hasher, inner);
+    let result = outer_hasher.finalize();
+
+    // Zeroizar temporales (defense in depth)
+    key_block.zeroize();
+    ipad.zeroize();
+    opad.zeroize();
+
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&result);
+    out
+}
+
+/// HKDF-SHA3-256: Extract + Expand (un solo bloque, 32 bytes de salida).
+///
+/// Implementa RFC 5869 con SHA3-256 como funcion hash.
+/// Longitud de salida fija en 32 bytes (un solo bloque T(1) — sin loop de counter).
+///
+/// # Arguments
+/// - `password`: input keying material (IKM) — la contrasena del usuario
+/// - `salt`: 16 bytes aleatorios
+/// - `info`: context-specific info (ej: dominio "aegisq-key-wrap-v1")
+///
+/// # Returns
+/// 32 bytes de output keying material (OKM).
+pub(crate) fn hkdf_sha3_256(password: &[u8], salt: &[u8; 16], info: &[u8]) -> [u8; 32] {
+    // Extract: PRK = HMAC-Hash(salt, IKM)
+    let mut prk = hmac_sha3_256(salt, password);
+
+    // Expand: OKM = T(1) = HMAC-Hash(PRK, info || 0x01)
+    // Queremos exactamente 32 bytes = HashLen, un solo bloque T alcanza.
+    let mut expand_input = Zeroizing::new([0u8; 256]); // tamano generoso
+    let mut expand_len = 0;
+    if info.len() < 255 {
+        expand_input[..info.len()].copy_from_slice(info);
+        expand_len = info.len();
+        expand_input[expand_len] = 0x01;
+        expand_len += 1;
+    }
+    let okm = hmac_sha3_256(&prk, &expand_input[..expand_len]);
+
+    prk.zeroize();
+    okm
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// HMAC-SHA3-256 de clave vacia + data vacia — vector de prueba independiente.
+    /// Verificado contra Python stdlib:
+    ///   python3 -c "import hmac, hashlib; print(hmac.new(b'', b'', hashlib.sha3_256).hexdigest())"
+    /// = e841c164e5b4f10c9f3985587962af72fd607a951196fc92fb3a5251941784ea
+    #[test]
+    fn hmac_sha3_256_empty_inputs_matches_python_stdlib() {
+        let result = hmac_sha3_256(b"", b"");
+        let hex: alloc::string::String =
+            result.iter().map(|b| alloc::format!("{:02x}", b)).collect();
+        assert_eq!(
+            hex,
+            "e841c164e5b4f10c9f3985587962af72fd607a951196fc92fb3a5251941784ea",
+            "HMAC-SHA3-256 de inputs vacios debe coincidir con hmac stdlib de Python (hashlib.sha3_256)"
+        );
+    }
+
+    /// Vector RFC 4231 Test Case 1 adaptado a SHA3-256.
+    /// Python: hmac.new(b"\x0b"*20, b"Hi There", hashlib.sha3_256).hexdigest()
+    /// = ba85192310dffa96e2a3a40e69774351140bb7185e1202cdcc917589f95e16bb
+    #[test]
+    fn hmac_sha3_256_rfc4231_test_case_1_matches_python() {
+        let key = [0x0bu8; 20];
+        let data = b"Hi There";
+        let result = hmac_sha3_256(&key, data);
+        let hex: alloc::string::String =
+            result.iter().map(|b| alloc::format!("{:02x}", b)).collect();
+        assert_eq!(
+            hex,
+            "ba85192310dffa96e2a3a40e69774351140bb7185e1202cdcc917589f95e16bb",
+            "HMAC-SHA3-256 con clave 0x0b*20 y data 'Hi There' debe coincidir con Python"
+        );
+    }
+
+    #[test]
+    fn hkdf_sha3_256_is_deterministic() {
+        let salt = [1u8; 16];
+        let info = b"aegisq-test";
+        let a = hkdf_sha3_256(b"password", &salt, info);
+        let b = hkdf_sha3_256(b"password", &salt, info);
+        assert_eq!(a, b, "HKDF debe ser deterministico para los mismos inputs");
+    }
+
+    #[test]
+    fn hkdf_sha3_256_changes_with_salt() {
+        let info = b"aegisq-test";
+        let a = hkdf_sha3_256(b"password", &[1u8; 16], info);
+        let b = hkdf_sha3_256(b"password", &[2u8; 16], info);
+        assert_ne!(a, b, "Diferentes salts deben producir diferente OKM");
+    }
+
+    #[test]
+    fn hkdf_sha3_256_changes_with_info() {
+        let salt = [1u8; 16];
+        let a = hkdf_sha3_256(b"password", &salt, b"info-v1");
+        let b = hkdf_sha3_256(b"password", &salt, b"info-v2");
+        assert_ne!(a, b, "Diferentes info strings deben producir diferente OKM");
+    }
+
+    #[test]
+    fn hkdf_sha3_256_changes_with_password() {
+        let salt = [1u8; 16];
+        let info = b"aegisq-test";
+        let a = hkdf_sha3_256(b"password-A", &salt, info);
+        let b = hkdf_sha3_256(b"password-B", &salt, info);
+        assert_ne!(a, b, "Diferentes contrasenas deben producir diferente OKM");
+    }
+
+    /// HKDF con inputs vacios no debe panicar y debe producir un output fijo.
+    /// (Smoke test para edge cases.)
+    #[test]
+    fn hkdf_sha3_256_empty_inputs_does_not_panic() {
+        let salt = [0u8; 16];
+        let info: &[u8] = b"";
+        let _ = hkdf_sha3_256(b"", &salt, info);
+    }
+}

--- a/crates/aegisq-core/src/kem.rs
+++ b/crates/aegisq-core/src/kem.rs
@@ -298,3 +298,95 @@ mod tests {
         assert_eq!(decoded, keypair.public_key);
     }
 }
+
+// ── Validacion de tamano de llaves (v1.3.0) ─────────────────────────────
+
+/// Valida que los bytes corresponden al tamano esperado de una llave publica para el nivel dado.
+///
+/// # Errors
+/// - `AegisQError::InvalidParameter` si el tamano no coincide.
+pub fn validate_public_key_size(pk: &[u8], level: SecurityLevel) -> Result<(), AegisQError> {
+    let expected = level.public_key_size();
+    if pk.len() != expected {
+        return Err(AegisQError::InvalidParameter(
+            "public key size does not match the specified security level",
+        ));
+    }
+    Ok(())
+}
+
+/// Valida que los bytes corresponden al tamano esperado de una llave secreta para el nivel dado.
+///
+/// # Errors
+/// - `AegisQError::InvalidParameter` si el tamano no coincide.
+pub fn validate_secret_key_size(sk: &[u8], level: SecurityLevel) -> Result<(), AegisQError> {
+    let expected = level.secret_key_size();
+    if sk.len() != expected {
+        return Err(AegisQError::InvalidParameter(
+            "secret key size does not match the specified security level",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::*;
+
+    #[test]
+    fn validate_public_key_size_accepts_correct_sizes() {
+        for level in [
+            SecurityLevel::MlKem512,
+            SecurityLevel::MlKem768,
+            SecurityLevel::MlKem1024,
+        ] {
+            let pk = alloc::vec![0u8; level.public_key_size()];
+            assert!(
+                validate_public_key_size(&pk, level).is_ok(),
+                "valid size for {level:?} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_public_key_size_rejects_wrong_sizes() {
+        let pk = alloc::vec![0u8; 100];
+        assert!(matches!(
+            validate_public_key_size(&pk, SecurityLevel::MlKem768),
+            Err(AegisQError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn validate_public_key_size_rejects_empty() {
+        let pk: &[u8] = &[];
+        assert!(matches!(
+            validate_public_key_size(pk, SecurityLevel::MlKem768),
+            Err(AegisQError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn validate_secret_key_size_accepts_correct_sizes() {
+        for level in [
+            SecurityLevel::MlKem512,
+            SecurityLevel::MlKem768,
+            SecurityLevel::MlKem1024,
+        ] {
+            let sk = alloc::vec![0u8; level.secret_key_size()];
+            assert!(
+                validate_secret_key_size(&sk, level).is_ok(),
+                "valid size for {level:?} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_secret_key_size_rejects_wrong_sizes() {
+        let sk = alloc::vec![0u8; 100];
+        assert!(matches!(
+            validate_secret_key_size(&sk, SecurityLevel::MlKem768),
+            Err(AegisQError::InvalidParameter(_))
+        ));
+    }
+}

--- a/crates/aegisq-core/src/key_wrap.rs
+++ b/crates/aegisq-core/src/key_wrap.rs
@@ -1,0 +1,337 @@
+//! Cifrado/descifrado de llaves privadas ML-KEM con AES-256-GCM + HKDF-SHA3-256.
+//!
+//! El formato del blob binario (en orden, little-endian layout) es:
+//!
+//! - 4 bytes: magic `"AQPK"`
+//! - 1 byte:  version = 1
+//! - 1 byte:  level_id (0=512, 1=768, 2=1024)
+//! - 16 bytes: salt HKDF
+//! - 12 bytes: nonce AES-GCM
+//! - N bytes:  ciphertext AES-GCM de secret_key
+//! - 16 bytes: tag AES-GCM
+//!
+//! **JAMAS exporta la llave privada en texto plano.** La contrasena del usuario
+//! es requerida para recuperar la llave.
+//!
+//! Reglas de seguridad:
+//! - La clave derivada de HKDF vive en `Zeroizing<[u8; 32]>` y se borra al salir del scope.
+//! - `salt` y `nonce` son generados externamente (Capa 2 con `getrandom`) y pasados
+//!   como parametros. Asi la Capa 1 permanece pura y no_std-friendly.
+//! - Contrasena incorrecta → `AegisQError::DecryptionFailed` (INDISTINGUIBLE de
+//!   blob corrupto, para no dar informacion al atacante).
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use alloc::vec::Vec;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::error::AegisQError;
+use crate::kem::SecurityLevel;
+use crate::kdf::hkdf_sha3_256;
+
+/// Magic bytes que identifican un blob AegisQ.
+pub const MAGIC: &[u8; 4] = b"AQPK";
+
+/// Version actual del formato de blob.
+pub const VERSION: u8 = 1;
+
+/// Header fijo del blob: magic(4) + version(1) + level_id(1) = 6 bytes.
+pub const HEADER_SIZE: usize = 6;
+
+/// Tamano del salt HKDF en bytes.
+pub const SALT_SIZE: usize = 16;
+
+/// Tamano del nonce AES-GCM en bytes (96 bits, mismo que hybrid.rs).
+pub const NONCE_SIZE: usize = 12;
+
+/// Tamano del tag AES-GCM en bytes (128 bits, mismo que hybrid.rs).
+pub const TAG_SIZE: usize = 16;
+
+/// Domain separation string para HKDF-Expand (NIST SP 800-108 style).
+const HKDF_INFO: &[u8] = b"aegisq-key-wrap-v1";
+
+/// Codifica un `SecurityLevel` a su byte identificador en el blob.
+fn level_to_id(level: SecurityLevel) -> u8 {
+    match level {
+        SecurityLevel::MlKem512 => 0,
+        SecurityLevel::MlKem768 => 1,
+        SecurityLevel::MlKem1024 => 2,
+    }
+}
+
+/// Decodifica un byte identificador a `SecurityLevel`. Retorna error si es desconocido.
+fn id_to_level(id: u8) -> Result<SecurityLevel, AegisQError> {
+    match id {
+        0 => Ok(SecurityLevel::MlKem512),
+        1 => Ok(SecurityLevel::MlKem768),
+        2 => Ok(SecurityLevel::MlKem1024),
+        _ => Err(AegisQError::KeySerializationError(
+            "unknown level_id in wrapped blob",
+        )),
+    }
+}
+
+/// Cifra una llave secreta ML-KEM con una contrasena, retorna blob binario opaco.
+///
+/// # Arguments
+/// - `secret_key`: bytes crudos de la llave secreta
+/// - `password`: contrasena del usuario (cualquier longitud)
+/// - `level`: nivel de seguridad (codificado en el blob)
+/// - `rng_salt`: 16 bytes aleatorios (generados por el caller con `getrandom`)
+/// - `rng_nonce`: 12 bytes aleatorios (generados por el caller con `getrandom`)
+///
+/// # Errors
+/// - `AegisQError::InvalidParameter` si `secret_key.len()` no coincide con `level.secret_key_size()`.
+pub fn wrap_secret_key(
+    secret_key: &[u8],
+    password: &[u8],
+    level: SecurityLevel,
+    rng_salt: [u8; SALT_SIZE],
+    rng_nonce: [u8; NONCE_SIZE],
+) -> Result<Vec<u8>, AegisQError> {
+    // 1. Validar tamano de la llave secreta para el nivel dado
+    if secret_key.len() != level.secret_key_size() {
+        return Err(AegisQError::InvalidParameter(
+            "secret key size does not match the specified security level",
+        ));
+    }
+
+    // 2. Derivar la clave de cifrado via HKDF-SHA3-256 (32 bytes para AES-256)
+    let mut wrap_key = Zeroizing::new(hkdf_sha3_256(password, &rng_salt, HKDF_INFO));
+
+    // 3. AES-256-GCM encrypt
+    let cipher = Aes256Gcm::new_from_slice(&*wrap_key)
+        .map_err(|_| AegisQError::KeySerializationError("invalid derived key length"))?;
+    let nonce = Nonce::from_slice(&rng_nonce);
+    let ct_with_tag = cipher
+        .encrypt(nonce, secret_key)
+        .map_err(|_| AegisQError::KeySerializationError("AES-GCM encrypt failed"))?;
+
+    // 4. Ensamblar blob en el orden canonico
+    let mut blob = Vec::with_capacity(HEADER_SIZE + SALT_SIZE + NONCE_SIZE + ct_with_tag.len());
+    blob.extend_from_slice(MAGIC);
+    blob.push(VERSION);
+    blob.push(level_to_id(level));
+    blob.extend_from_slice(&rng_salt);
+    blob.extend_from_slice(&rng_nonce);
+    blob.extend_from_slice(&ct_with_tag);
+
+    // 5. Zeroizar la clave derivada explicitamente (Zeroizing tambien lo haria en drop)
+    wrap_key.zeroize();
+
+    Ok(blob)
+}
+
+/// Descifra un blob y retorna la llave secreta en `Zeroizing<Vec<u8>>`.
+///
+/// # Arguments
+/// - `blob`: bytes del blob producido por `wrap_secret_key`
+/// - `password`: contrasena usada al cifrar
+///
+/// # Returns
+/// Tupla `(secret_key_bytes, security_level)` con borrado automatico de memoria
+/// al salir del scope.
+///
+/// # Errors
+/// - `AegisQError::KeySerializationError` si magic/version son invalidos o el blob esta truncado.
+/// - `AegisQError::DecryptionFailed` si la contrasena es incorrecta o el tag AES-GCM no verifica.
+///   (El error es INDISTINGUIBLE entre "contrasena incorrecta" y "blob corrupto".)
+pub fn unwrap_secret_key(
+    blob: &[u8],
+    password: &[u8],
+) -> Result<(Zeroizing<Vec<u8>>, SecurityLevel), AegisQError> {
+    // 1. Validar longitud minima: header(6) + salt(16) + nonce(12) + tag(16) = 50 bytes
+    if blob.len() < HEADER_SIZE + SALT_SIZE + NONCE_SIZE + TAG_SIZE {
+        return Err(AegisQError::KeySerializationError(
+            "wrapped blob is too short to contain a valid header",
+        ));
+    }
+
+    // 2. Verificar magic bytes
+    if &blob[..4] != MAGIC {
+        return Err(AegisQError::KeySerializationError(
+            "invalid magic bytes in wrapped blob",
+        ));
+    }
+
+    // 3. Verificar version
+    if blob[4] != VERSION {
+        return Err(AegisQError::KeySerializationError(
+            "unsupported wrapped blob version",
+        ));
+    }
+
+    // 4. Decodificar nivel
+    let level = id_to_level(blob[5])?;
+
+    // 5. Extraer salt y nonce
+    let salt: [u8; SALT_SIZE] = blob[HEADER_SIZE..HEADER_SIZE + SALT_SIZE]
+        .try_into()
+        .map_err(|_| AegisQError::KeySerializationError("failed to extract salt from blob"))?;
+    let nonce_bytes: [u8; NONCE_SIZE] = blob
+        [HEADER_SIZE + SALT_SIZE..HEADER_SIZE + SALT_SIZE + NONCE_SIZE]
+        .try_into()
+        .map_err(|_| AegisQError::KeySerializationError("failed to extract nonce from blob"))?;
+
+    // 6. Extraer ciphertext || tag (resto del blob)
+    let ct_with_tag = &blob[HEADER_SIZE + SALT_SIZE + NONCE_SIZE..];
+
+    // 7. Derivar la clave de descifrado
+    let mut wrap_key = Zeroizing::new(hkdf_sha3_256(password, &salt, HKDF_INFO));
+
+    // 8. AES-256-GCM decrypt — CRITICO: tag failure -> DecryptionFailed (no KeySerializationError)
+    let cipher = Aes256Gcm::new_from_slice(&*wrap_key)
+        .map_err(|_| AegisQError::KeySerializationError("invalid derived key length"))?;
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let plaintext = cipher
+        .decrypt(nonce, ct_with_tag)
+        .map_err(|_| AegisQError::DecryptionFailed)?;
+
+    // 9. Validar que la longitud recuperada coincida con el tamano esperado para el nivel
+    if plaintext.len() != level.secret_key_size() {
+        // Tratar como fallo de autenticacion (no filtrar que el tamano fue incorrecto)
+        return Err(AegisQError::DecryptionFailed);
+    }
+
+    wrap_key.zeroize();
+    Ok((Zeroizing::new(plaintext), level))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Roundtrip basico: wrap -> unwrap con contrasena correcta -> recupera bytes originales.
+    #[test]
+    fn roundtrip_ml_kem_768() {
+        let sk = alloc::vec![0x42u8; SecurityLevel::MlKem768.secret_key_size()];
+        let salt = [1u8; SALT_SIZE];
+        let nonce = [2u8; NONCE_SIZE];
+        let blob = wrap_secret_key(
+            &sk,
+            b"correct-horse-battery-staple",
+            SecurityLevel::MlKem768,
+            salt,
+            nonce,
+        )
+        .expect("wrap must succeed");
+        let (recovered, level) =
+            unwrap_secret_key(&blob, b"correct-horse-battery-staple")
+                .expect("unwrap with correct password must succeed");
+        assert_eq!(level, SecurityLevel::MlKem768);
+        assert_eq!(&*recovered, &sk[..]);
+    }
+
+    #[test]
+    fn roundtrip_all_levels() {
+        for level in [
+            SecurityLevel::MlKem512,
+            SecurityLevel::MlKem768,
+            SecurityLevel::MlKem1024,
+        ] {
+            let sk = alloc::vec![0xABu8; level.secret_key_size()];
+            let salt = [3u8; SALT_SIZE];
+            let nonce = [4u8; NONCE_SIZE];
+            let blob = wrap_secret_key(&sk, b"pwd", level, salt, nonce)
+                .expect("wrap must succeed");
+            let (recovered, recovered_level) = unwrap_secret_key(&blob, b"pwd")
+                .expect("unwrap must succeed");
+            assert_eq!(recovered_level, level);
+            assert_eq!(&*recovered, &sk[..]);
+        }
+    }
+
+    #[test]
+    fn wrong_password_raises_decryption_failed() {
+        let sk = alloc::vec![0x42u8; SecurityLevel::MlKem768.secret_key_size()];
+        let salt = [5u8; SALT_SIZE];
+        let nonce = [6u8; NONCE_SIZE];
+        let blob = wrap_secret_key(&sk, b"correct", SecurityLevel::MlKem768, salt, nonce)
+            .expect("wrap must succeed");
+        let result = unwrap_secret_key(&blob, b"WRONG");
+        assert!(
+            matches!(result, Err(AegisQError::DecryptionFailed)),
+            "contrasena incorrecta DEBE producir DecryptionFailed (no KeySerializationError) — requisito de seguridad"
+        );
+    }
+
+    #[test]
+    fn invalid_magic_raises_key_serialization_error() {
+        let mut blob = alloc::vec![0u8; 100];
+        blob[..4].copy_from_slice(b"XXXX");
+        let result = unwrap_secret_key(&blob, b"pwd");
+        assert!(matches!(
+            result,
+            Err(AegisQError::KeySerializationError(_))
+        ));
+    }
+
+    #[test]
+    fn truncated_blob_raises_key_serialization_error() {
+        let blob = alloc::vec![0u8; 10];
+        let result = unwrap_secret_key(&blob, b"pwd");
+        assert!(matches!(
+            result,
+            Err(AegisQError::KeySerializationError(_))
+        ));
+    }
+
+    #[test]
+    fn wrong_version_raises_key_serialization_error() {
+        let mut blob = alloc::vec![0u8; 100];
+        blob[..4].copy_from_slice(MAGIC);
+        blob[4] = 99;
+        let result = unwrap_secret_key(&blob, b"pwd");
+        assert!(matches!(
+            result,
+            Err(AegisQError::KeySerializationError(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_level_id_raises_key_serialization_error() {
+        let mut blob = alloc::vec![0u8; 100];
+        blob[..4].copy_from_slice(MAGIC);
+        blob[4] = VERSION;
+        blob[5] = 99;
+        let result = unwrap_secret_key(&blob, b"pwd");
+        assert!(matches!(
+            result,
+            Err(AegisQError::KeySerializationError(_))
+        ));
+    }
+
+    #[test]
+    fn wrong_size_secret_key_raises_invalid_parameter() {
+        let sk = alloc::vec![0u8; 100];
+        let salt = [7u8; SALT_SIZE];
+        let nonce = [8u8; NONCE_SIZE];
+        let result = wrap_secret_key(&sk, b"pwd", SecurityLevel::MlKem768, salt, nonce);
+        assert!(matches!(result, Err(AegisQError::InvalidParameter(_))));
+    }
+
+    #[test]
+    fn blob_has_correct_layout() {
+        let sk = alloc::vec![0u8; SecurityLevel::MlKem768.secret_key_size()];
+        let salt = [0xABu8; SALT_SIZE];
+        let nonce = [0xCDu8; NONCE_SIZE];
+        let blob = wrap_secret_key(&sk, b"pwd", SecurityLevel::MlKem768, salt, nonce)
+            .expect("wrap must succeed");
+
+        // Verificar magic al inicio
+        assert_eq!(&blob[..4], b"AQPK");
+        // Verificar version
+        assert_eq!(blob[4], 1);
+        // Verificar level_id (1 = MlKem768)
+        assert_eq!(blob[5], 1);
+        // Verificar salt en los siguientes 16 bytes
+        assert_eq!(&blob[6..22], &salt[..]);
+        // Verificar nonce en los siguientes 12 bytes
+        assert_eq!(&blob[22..34], &nonce[..]);
+        // Tamano total esperado: header(6) + salt(16) + nonce(12) + sk(2400) + tag(16) = 2450
+        assert_eq!(
+            blob.len(),
+            HEADER_SIZE + SALT_SIZE + NONCE_SIZE + sk.len() + TAG_SIZE
+        );
+    }
+}

--- a/crates/aegisq-core/src/lib.rs
+++ b/crates/aegisq-core/src/lib.rs
@@ -12,5 +12,7 @@ extern crate alloc;
 
 pub mod error;
 pub mod hybrid;
+pub mod kdf;
 pub mod kem;
+pub mod key_wrap;
 pub mod mlkem;

--- a/crates/aegisq-pyo3/Cargo.toml
+++ b/crates/aegisq-pyo3/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # abi3-py311: genera un único wheel ABI3 compatible con Python 3.11+
-pyo3        = { version = "0.28", features = ["extension-module", "abi3-py311"] }
+pyo3        = { version = "0.29", features = ["extension-module", "abi3-py311"] }
 aegisq-core = { path = "../aegisq-core" }
 getrandom   = { workspace = true }
 base64      = { workspace = true }

--- a/crates/aegisq-pyo3/Cargo.toml
+++ b/crates/aegisq-pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "aegisq-pyo3"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/aegisq-pyo3/Cargo.toml
+++ b/crates/aegisq-pyo3/Cargo.toml
@@ -13,3 +13,5 @@ crate-type = ["cdylib"]
 # abi3-py311: genera un único wheel ABI3 compatible con Python 3.11+
 pyo3        = { version = "0.28", features = ["extension-module", "abi3-py311"] }
 aegisq-core = { path = "../aegisq-core" }
+getrandom   = { workspace = true }
+base64      = { workspace = true }

--- a/crates/aegisq-pyo3/src/error.rs
+++ b/crates/aegisq-pyo3/src/error.rs
@@ -44,6 +44,12 @@ create_exception!(
     AegisQError,
     "CSPRNG not available from the operating system."
 );
+create_exception!(
+    aegisq,
+    KeySerializationError,
+    AegisQError,
+    "Invalid key serialization format (PEM header, JSON, magic bytes, truncated blob)."
+);
 
 /// Registra las excepciones customizadas en el modulo Python.
 pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -58,6 +64,10 @@ pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.py().get_type::<InvalidParameterError>(),
     )?;
     m.add("RngError", m.py().get_type::<RngError>())?;
+    m.add(
+        "KeySerializationError",
+        m.py().get_type::<KeySerializationError>(),
+    )?;
     Ok(())
 }
 
@@ -79,6 +89,9 @@ pub fn core_error_to_pyerr(err: aegisq_core::error::AegisQError) -> PyErr {
         }
         aegisq_core::error::AegisQError::Base64DecodeError(msg) => {
             AegisQError::new_err(format!("base64 decode error: {}", msg))
+        }
+        aegisq_core::error::AegisQError::KeySerializationError(msg) => {
+            KeySerializationError::new_err(msg.to_string())
         }
     }
 }

--- a/crates/aegisq-pyo3/src/key_io_bindings.rs
+++ b/crates/aegisq-pyo3/src/key_io_bindings.rs
@@ -1,0 +1,253 @@
+//! Funciones PyO3 para serializacion y carga de llaves ML-KEM (v1.3.0).
+//!
+//! Exporta:
+//! - load_public_key_pem, load_public_key_json
+//! - load_secret_key_raw, load_secret_key_pem
+//!
+//! Estas funciones operan sobre bytes/strings y NO dependen de la clase KeyPair.
+//! La Capa 3 (Python) las envuelve con la API de alto nivel (save_/load_).
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use crate::error::core_error_to_pyerr;
+use crate::types::SecurityLevel;
+use aegisq_core::kem::{
+    self,
+    SecurityLevel as CoreSecurityLevel,
+};
+use aegisq_core::key_wrap;
+
+// ── Constantes de formato PEM ────────────────────────────────────────────
+
+const PEM_PUBLIC_HEADER: &str = "-----BEGIN ML-KEM PUBLIC KEY-----";
+const PEM_PUBLIC_FOOTER: &str = "-----END ML-KEM PUBLIC KEY-----";
+const PEM_ENCRYPTED_HEADER: &str = "-----BEGIN ENCRYPTED ML-KEM PRIVATE KEY-----";
+const PEM_ENCRYPTED_FOOTER: &str = "-----END ENCRYPTED ML-KEM PRIVATE KEY-----";
+
+/// Une las lineas de un cuerpo PEM en un solo string sin saltos de linea.
+fn unwrap_pem_body(body: &str) -> String {
+    body.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+/// Extrae el cuerpo entre header y footer. Retorna error si falta alguno.
+fn extract_pem_body<'a>(
+    pem: &'a str,
+    header: &str,
+    footer: &str,
+) -> Result<&'a str, aegisq_core::error::AegisQError> {
+    let after_header = pem
+        .find(header)
+        .ok_or(aegisq_core::error::AegisQError::KeySerializationError(
+            "PEM header not found",
+        ))?;
+    let body_start = after_header + header.len();
+    let after_footer = pem[body_start..]
+        .find(footer)
+        .ok_or(aegisq_core::error::AegisQError::KeySerializationError(
+            "PEM footer not found",
+        ))?;
+    Ok(&pem[body_start..body_start + after_footer])
+}
+
+// ── Funciones de carga de llave PUBLICA ──────────────────────────────────
+
+/// Carga una llave publica desde formato PEM-like ML-KEM.
+///
+/// Args:
+///     pem (str): String PEM con el header `-----BEGIN ML-KEM PUBLIC KEY-----`.
+///     level (SecurityLevel): Nivel de seguridad esperado.
+///
+/// Returns:
+///     bytes: La llave publica lista para pasar a `AegisCipher.encrypt()`.
+///
+/// Raises:
+///     KeySerializationError: Si el PEM no tiene header/footer o el Base64 es invalido.
+///     InvalidParameterError: Si el tamano no coincide con el nivel.
+#[pyfunction]
+#[pyo3(signature = (pem, level=SecurityLevel::MlKem768))]
+pub fn load_public_key_pem<'py>(
+    py: Python<'py>,
+    pem: &str,
+    level: SecurityLevel,
+) -> PyResult<Bound<'py, PyBytes>> {
+    let core_level: CoreSecurityLevel = level.into();
+
+    let body = extract_pem_body(pem, PEM_PUBLIC_HEADER, PEM_PUBLIC_FOOTER)
+        .map_err(core_error_to_pyerr)?;
+
+    let b64 = unwrap_pem_body(body);
+    let bytes = STANDARD
+        .decode(&b64)
+        .map_err(|_| aegisq_core::error::AegisQError::KeySerializationError(
+            "PEM body is not valid Base64 STANDARD",
+        ))
+        .map_err(core_error_to_pyerr)?;
+
+    // Validar tamano para el nivel — AegisQError::InvalidParameter se mapea solo
+    kem::validate_public_key_size(&bytes, core_level).map_err(core_error_to_pyerr)?;
+
+    Ok(PyBytes::new(py, &bytes))
+}
+
+/// Carga una llave publica desde JSON.
+///
+/// El JSON debe tener los campos:
+///   - "algorithm": "ML-KEM"
+///   - "level": uno de "ML_KEM_512", "ML_KEM_768", "ML_KEM_1024"
+///   - "public_key": Base64 URL-safe sin padding
+///
+/// Returns:
+///     tuple[bytes, SecurityLevel]: (llave_publica, nivel)
+///
+/// Raises:
+///     KeySerializationError: Si el JSON es invalido o le faltan campos.
+///     InvalidParameterError: Si el tamano no coincide con el nivel declarado.
+#[pyfunction]
+pub fn load_public_key_json<'py>(
+    py: Python<'py>,
+    json: &str,
+) -> PyResult<(Bound<'py, PyBytes>, SecurityLevel)> {
+    // Parsing manual minimo para evitar dependencia de serde.
+    // Formato esperado: {"algorithm":"...","level":"...","public_key":"..."}
+    let algorithm = extract_json_string(json, "algorithm")
+        .map_err(core_error_to_pyerr)?;
+    let level_str = extract_json_string(json, "level").map_err(core_error_to_pyerr)?;
+    let public_key_b64 = extract_json_string(json, "public_key").map_err(core_error_to_pyerr)?;
+
+    if algorithm != "ML-KEM" {
+        return Err(core_error_to_pyerr(
+            aegisq_core::error::AegisQError::KeySerializationError(
+                "unsupported algorithm (expected 'ML-KEM')",
+            ),
+        ));
+    }
+
+    let core_level = match level_str.as_str() {
+        "ML_KEM_512" => CoreSecurityLevel::MlKem512,
+        "ML_KEM_768" => CoreSecurityLevel::MlKem768,
+        "ML_KEM_1024" => CoreSecurityLevel::MlKem1024,
+        _ => {
+            return Err(core_error_to_pyerr(
+                aegisq_core::error::AegisQError::KeySerializationError(
+                    "unsupported level in JSON (expected ML_KEM_512/768/1024)",
+                ),
+            ));
+        }
+    };
+
+    // Decodifica con la funcion existente (URL-safe sin padding, con trim de whitespace).
+    let bytes = kem::public_key_from_b64(&public_key_b64, core_level)
+        .map_err(core_error_to_pyerr)?;
+
+    Ok((PyBytes::new(py, &bytes), level_from_core(core_level)))
+}
+
+fn level_from_core(level: CoreSecurityLevel) -> SecurityLevel {
+    match level {
+        CoreSecurityLevel::MlKem512 => SecurityLevel::MlKem512,
+        CoreSecurityLevel::MlKem768 => SecurityLevel::MlKem768,
+        CoreSecurityLevel::MlKem1024 => SecurityLevel::MlKem1024,
+    }
+}
+
+/// Extrae el valor string de un campo en un JSON muy simple (sin escapes).
+/// Espera formato `"key":"value"` sin espacios. Suficiente para nuestros casos.
+fn extract_json_string(
+    json: &str,
+    key: &str,
+) -> Result<alloc::string::String, aegisq_core::error::AegisQError> {
+    let needle = alloc::format!("\"{}\":", key);
+    let key_pos = json
+        .find(&needle)
+        .ok_or(aegisq_core::error::AegisQError::KeySerializationError(
+            "missing JSON field",
+        ))?;
+    let after_key = key_pos + needle.len();
+    let rest = &json[after_key..];
+    let rest = rest.trim_start();
+
+    // Esperamos string que empieza con "
+    let rest = rest
+        .strip_prefix('"')
+        .ok_or(aegisq_core::error::AegisQError::KeySerializationError(
+            "JSON field value is not a string",
+        ))?;
+    let end = rest
+        .find('"')
+        .ok_or(aegisq_core::error::AegisQError::KeySerializationError(
+            "unterminated JSON string value",
+        ))?;
+    Ok(alloc::string::String::from(&rest[..end]))
+}
+
+extern crate alloc;
+
+// ── Funciones de carga de llave PRIVADA ──────────────────────────────────
+
+/// Descifra y retorna la llave secreta desde un blob binario.
+///
+/// Args:
+///     blob (bytes): Blob producido por `KeyPair.export_secret_key_raw`.
+///     password (bytes): Contrasena usada al cifrar.
+///
+/// Returns:
+///     tuple[bytes, SecurityLevel]: (secret_key, nivel)
+///
+/// Raises:
+///     DecryptionError: Si la contrasena es incorrecta o el blob esta corrupto.
+///     KeySerializationError: Si magic/version son invalidos o el blob esta truncado.
+#[pyfunction]
+pub fn load_secret_key_raw<'py>(
+    py: Python<'py>,
+    blob: &[u8],
+    password: &[u8],
+) -> PyResult<(Bound<'py, PyBytes>, SecurityLevel)> {
+    let result = py.detach(|| key_wrap::unwrap_secret_key(blob, password));
+    match result {
+        Ok((sk, core_level)) => Ok((
+            PyBytes::new(py, &sk),
+            level_from_core(core_level),
+        )),
+        Err(e) => Err(core_error_to_pyerr(e)),
+    }
+}
+
+/// Descifra y retorna la llave secreta desde un PEM-like ENCRYPTED.
+///
+/// Args:
+///     pem (str): String PEM con header `-----BEGIN ENCRYPTED ML-KEM PRIVATE KEY-----`.
+///     password (bytes): Contrasena usada al cifrar.
+///
+/// Returns:
+///     tuple[bytes, SecurityLevel]: (secret_key, nivel)
+///
+/// Raises:
+///     DecryptionError: Si la contrasena es incorrecta o el blob esta corrupto.
+///     KeySerializationError: Si el PEM/Base64/magic son invalidos.
+#[pyfunction]
+pub fn load_secret_key_pem<'py>(
+    py: Python<'py>,
+    pem: &str,
+    password: &[u8],
+) -> PyResult<(Bound<'py, PyBytes>, SecurityLevel)> {
+    let body = extract_pem_body(pem, PEM_ENCRYPTED_HEADER, PEM_ENCRYPTED_FOOTER)
+        .map_err(core_error_to_pyerr)?;
+    let b64 = unwrap_pem_body(body);
+    let blob = STANDARD
+        .decode(&b64)
+        .map_err(|_| aegisq_core::error::AegisQError::KeySerializationError(
+            "PEM ENCRYPTED body is not valid Base64 STANDARD",
+        ))
+        .map_err(core_error_to_pyerr)?;
+
+    let result = py.detach(|| key_wrap::unwrap_secret_key(&blob, password));
+    match result {
+        Ok((sk, core_level)) => Ok((
+            PyBytes::new(py, &sk),
+            level_from_core(core_level),
+        )),
+        Err(e) => Err(core_error_to_pyerr(e)),
+    }
+}

--- a/crates/aegisq-pyo3/src/lib.rs
+++ b/crates/aegisq-pyo3/src/lib.rs
@@ -12,6 +12,7 @@ use pyo3::prelude::*;
 mod error;
 mod hybrid_bindings;
 mod kem_bindings;
+mod key_io_bindings;
 mod types;
 
 /// Modulo Python `_aegisq_core`.
@@ -48,6 +49,12 @@ fn _aegisq_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Registrar funciones hibridas
     m.add_function(wrap_pyfunction!(hybrid_bindings::encrypt_hybrid, m)?)?;
     m.add_function(wrap_pyfunction!(hybrid_bindings::decrypt_hybrid, m)?)?;
+
+    // Registrar funciones de carga/serializacion de llaves (v1.3.0)
+    m.add_function(wrap_pyfunction!(key_io_bindings::load_public_key_pem, m)?)?;
+    m.add_function(wrap_pyfunction!(key_io_bindings::load_public_key_json, m)?)?;
+    m.add_function(wrap_pyfunction!(key_io_bindings::load_secret_key_raw, m)?)?;
+    m.add_function(wrap_pyfunction!(key_io_bindings::load_secret_key_pem, m)?)?;
 
     Ok(())
 }

--- a/crates/aegisq-pyo3/src/types.rs
+++ b/crates/aegisq-pyo3/src/types.rs
@@ -4,8 +4,14 @@
 //! - SecurityLevel: enum con los 3 niveles de seguridad
 //! - KeyPair: par de claves (public_key, secret_key)
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+
+use aegisq_core::key_wrap;
+use aegisq_core::kem::SecurityLevel as CoreSecurityLevel;
+
+use crate::error::core_error_to_pyerr;
 
 /// Nivel de seguridad ML-KEM.
 ///
@@ -83,7 +89,106 @@ impl KeyPair {
     fn public_key_b64(&self) -> String {
         aegisq_core::kem::public_key_to_b64(&self.public_key_bytes)
     }
+
+    // ── Serializacion v1.3.0 ────────────────────────────────────────
+
+    /// Exporta la clave publica en formato PEM-like ML-KEM.
+    ///
+    /// Formato::
+    ///
+    ///     -----BEGIN ML-KEM PUBLIC KEY-----
+    ///     <Base64 STANDARD, lineas de 64 chars>
+    ///     -----END ML-KEM PUBLIC KEY-----
+    ///
+    /// No es DER/ASN.1. Es un formato propietario legible inspirado en PEM.
+    ///
+    /// Returns:
+    ///     str: La clave publica en formato PEM.
+    fn public_key_pem(&self) -> String {
+        const HEADER: &str = "-----BEGIN ML-KEM PUBLIC KEY-----";
+        const FOOTER: &str = "-----END ML-KEM PUBLIC KEY-----";
+        let body = wrap_pem_lines(&STANDARD.encode(&self.public_key_bytes), 64);
+        alloc::format!("{HEADER}\n{body}\n{FOOTER}\n")
+    }
+
+    /// Exporta la clave publica en formato JSON.
+    ///
+    /// JSON con campos: algorithm ("ML-KEM"), level ("ML_KEM_512/768/1024"),
+    /// public_key (Base64 URL-safe sin padding).
+    ///
+    /// Returns:
+    ///     str: La clave publica serializada como JSON.
+    fn public_key_json(&self) -> String {
+        let level_name = match self.level {
+            SecurityLevel::MlKem512 => "ML_KEM_512",
+            SecurityLevel::MlKem768 => "ML_KEM_768",
+            SecurityLevel::MlKem1024 => "ML_KEM_1024",
+        };
+        let pk_b64 = aegisq_core::kem::public_key_to_b64(&self.public_key_bytes);
+        alloc::format!(
+            "{{\"algorithm\":\"ML-KEM\",\"level\":\"{}\",\"public_key\":\"{}\"}}",
+            level_name,
+            pk_b64
+        )
+    }
+
+    /// Exporta la clave secreta cifrada como blob binario opaco.
+    ///
+    /// Layout del blob: magic("AQPK") | version(1) | level_id(1) | salt(16)
+    /// | nonce(12) | ciphertext | tag(16). Se cifra con AES-256-GCM usando
+    /// una clave derivada de `password` via HKDF-SHA3-256.
+    ///
+    /// Libera el GIL durante HKDF + AES-GCM.
+    ///
+    /// Args:
+    ///     password (bytes): Contrasena para derivar la clave de cifrado.
+    ///
+    /// Returns:
+    ///     bytes: Blob binario opaco listo para persistir.
+    ///
+    /// Raises:
+    ///     RngError: Si el CSPRNG no esta disponible.
+    ///     InvalidParameterError: Si la llave secreta tiene tamano incorrecto.
+    fn export_secret_key_raw<'py>(
+        &self,
+        py: Python<'py>,
+        password: &[u8],
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        let blob = py
+            .detach(|| self.wrap_secret_key_blob(password))
+            .map_err(core_error_to_pyerr)?;
+        Ok(PyBytes::new(py, &blob))
+    }
+
+    /// Exporta la clave secreta cifrada en formato PEM-like ENCRYPTED.
+    ///
+    /// Formato::
+    ///
+    ///     -----BEGIN ENCRYPTED ML-KEM PRIVATE KEY-----
+    ///     <Base64 STANDARD del blob cifrado>
+    ///     -----END ENCRYPTED ML-KEM PRIVATE KEY-----
+    ///
+    /// Args:
+    ///     password (bytes): Contrasena para cifrar.
+    ///
+    /// Returns:
+    ///     str: La clave privada cifrada como PEM.
+    fn export_secret_key_pem<'py>(
+        &self,
+        py: Python<'py>,
+        password: &[u8],
+    ) -> PyResult<String> {
+        let blob = py
+            .detach(|| self.wrap_secret_key_blob(password))
+            .map_err(core_error_to_pyerr)?;
+        const HEADER: &str = "-----BEGIN ENCRYPTED ML-KEM PRIVATE KEY-----";
+        const FOOTER: &str = "-----END ENCRYPTED ML-KEM PRIVATE KEY-----";
+        let body = wrap_pem_lines(&STANDARD.encode(&blob), 64);
+        Ok(alloc::format!("{HEADER}\n{body}\n{FOOTER}\n"))
+    }
 }
+
+extern crate alloc;
 
 impl KeyPair {
     /// Constructor interno (no expuesto a Python directamente).
@@ -94,4 +199,34 @@ impl KeyPair {
             level,
         }
     }
+
+    /// Helper privado: cifra la secret_key con la contrasena y retorna el blob binario.
+    /// Usado tanto por `export_secret_key_raw` como por `export_secret_key_pem`.
+    ///
+    /// Genera salt y nonce con `getrandom`, luego delega a `aegisq_core::key_wrap`.
+    /// Esta funcion NO toca el GIL — el caller debe usar `py.detach(...)`.
+    fn wrap_secret_key_blob(&self, password: &[u8]) -> Result<alloc::vec::Vec<u8>, aegisq_core::error::AegisQError> {
+        let core_level: CoreSecurityLevel = self.level.into();
+
+        // Generar salt + nonce en Capa 2 (NO en Capa 1 — se mantiene pura).
+        let mut salt = [0u8; key_wrap::SALT_SIZE];
+        let mut nonce = [0u8; key_wrap::NONCE_SIZE];
+        getrandom::fill(&mut salt).map_err(|_| aegisq_core::error::AegisQError::RngError)?;
+        getrandom::fill(&mut nonce).map_err(|_| aegisq_core::error::AegisQError::RngError)?;
+
+        key_wrap::wrap_secret_key(&self.secret_key_bytes, password, core_level, salt, nonce)
+    }
+}
+
+/// Helper privado: divide un string Base64 en lineas de longitud `width`.
+/// Usado por los metodos que generan PEM.
+fn wrap_pem_lines(b64: &str, width: usize) -> alloc::string::String {
+    let mut out = alloc::string::String::with_capacity(b64.len() + b64.len() / width);
+    for (i, ch) in b64.chars().enumerate() {
+        if i > 0 && i % width == 0 {
+            out.push('\n');
+        }
+        out.push(ch);
+    }
+    out
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,13 +1,24 @@
-# AegisQ — cargo-deny configuration
+# cargo-deny configuration for AegisQ
 # Docs: https://embarkstudios.github.io/cargo-deny/
-# La versión efectiva de cargo-deny depende de la versión de
-# EmbarkStudios/cargo-deny-action configurada en CI.
+#
+# Schema actual (cargo-deny 0.19):
+# - [licenses] ya NO tiene keys deprecadas (deny/unlicensed/copyleft removidas).
+#   Cualquier licencia NO listada en `allow` es denegada por default.
+# - [advisories] requiere `unmaintained = "all"|"workspace"|"transitive"|"none"`.
 
-# ── Licencias ──────────────────────────────────────────────────────────────────
+[graph]
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+]
+
 [licenses]
-# Todas las licencias se deniegan a menos que estén en esta lista.
-# Se usan expresiones SPDX completas para cubrir todos los orderings
-# de licenses compuestos ("MIT OR Apache-2.0" vs "Apache-2.0 OR MIT").
+# Licencias aprobadas para AegisQ (todo el dependency tree).
+# Cualquier licencia NO en esta lista es denegada automaticamente, incluyendo
+# GPL-2/3, LGPL-2/2.1/3, AGPL-3.0 — comportamiento por default de cargo-deny.
 allow = [
     "MIT",
     "Apache-2.0",
@@ -16,65 +27,40 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
 ]
+confidence-threshold = 0.8
 
-# Umbral de confianza para la detección automática de licencias via askalono.
-# 0.8 es el default; 0.9 es más estricto y recomendado para proyectos de seguridad.
-confidence-threshold = 0.9
-
-# Los crates propios del workspace no necesitan licencia revisada (son el proyecto mismo).
-[licenses.private]
-ignore = true
-
-# ── Bans (duplicados y crates prohibidos) ──────────────────────────────────────
 [bans]
-# Denegar múltiples versiones del mismo crate. En un proyecto de seguridad,
-# versiones duplicadas son un vector de ataque (una puede tener CVE, la otra no).
-multiple-versions = "deny"
+# "warn" en v1.3.0 (pyo3 trae duplicados); subir a "deny" en v2.0.0.
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
 
-# Denegar dependencias con versión wildcard (*).
-wildcards = "deny"
-
-# Permite wildcards en path-dependencies de crates privados (nuestros propios crates).
-allow-wildcard-paths = true
-
-# Mostrar el camino más corto al duplicado en el grafo de dependencias.
-highlight = "simplest-path"
-
-# Crates explícitamente prohibidos en AegisQ.
-# openssl: Usar en su lugar rustls/aes-gcm del ecosistema RustCrypto.
+# Crates explicitamente prohibidos en AegisQ.
 deny = [
-    { crate = "openssl", use-instead = "aes-gcm", reason = "AegisQ usa exclusivamente RustCrypto. openssl introduce una FFI a C que rompe las garantías de seguridad de memoria." },
-    { crate = "native-tls", use-instead = "rustls", reason = "Same rationale as openssl." },
+    # Prohibir implementaciones de criptografia clasica vulnerable.
+    { name = "ring", reason = "Usar RustCrypto (sha3, aes-gcm) en su lugar" },
+    { name = "openssl", reason = "No se permite OpenSSL en el core" },
+    { name = "openssl-sys", reason = "No se permite OpenSSL en el core" },
 ]
 
-# Duplicados transitivos inevitables — crates WASM de target-lexicon/wit-bindgen
-# que no controlamos y que se resuelven a versiones distintas por el grafo de deps.
-# Estos se eliminan cuando los crates upstream actualicen sus deps.
-skip = [
-    "cpufeatures@0.2.17",
-    "cpufeatures@0.3.0",
-    "crypto-common@0.1.7",
-    "crypto-common@0.2.2",
-    "wit-bindgen@0.51.0",
-    "wit-bindgen@0.57.1",
-]
+skip = []
 
-# ── Advisories (CVEs) ──────────────────────────────────────────────────────────
 [advisories]
-# Base de datos de advisories de RustSec.
-# La URL por defecto apunta a https://github.com/RustSec/advisory-db
-# No es necesario configurar nada adicional; cargo-deny usa la DB oficial.
+# Sin advisories ignorados — cualquier vulnerabilidad publica debe bloquear CI.
+ignore = []
+# Crates unmaintained: solo falla si afecta deps directas del workspace.
+unmaintained = "workspace"
+# Crates yanked del registry: error.
+yanked = "deny"
 
-# Si un advisory no aplica al proyecto (e.g., solo afecta a una feature que no usamos),
-# se puede ignorar aquí con justificación:
-# ignore = ["RUSTSEC-XXXX-XXXX"]
-
-# ── Sources (orígenes permitidos) ──────────────────────────────────────────────
 [sources]
-# Solo se permiten crates de crates.io y del workspace local.
+# Solo permitir crates de crates.io (sin deps de git ni registries desconocidas).
 unknown-registry = "deny"
 unknown-git = "deny"
-
-# Repositorios git permitidos explícitamente (ninguno por ahora).
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegisq-pqc"
-version = "1.2.0"
+version = "1.3.0"
 description = "Post-quantum cryptography engine — Hybrid ML-KEM + AES-256-GCM (FIPS 203)"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/python/test_key_serialization.py
+++ b/tests/python/test_key_serialization.py
@@ -1,0 +1,355 @@
+"""Tests de serializacion de llaves ML-KEM (v1.3.0).
+
+Cubre los formatos PEM-like y JSON para llaves publicas, y el blob
+binario cifrado con contrasena (AES-256-GCM + HKDF-SHA3-256) para
+llaves privadas, segun spec §1.11.
+
+Organizacion:
+- TestPublicKeyPEM: round-trip, header/footer, line length
+- TestPublicKeyJSON: round-trip, contiene campo level
+- TestSecretKeyWrapUnwrap: cifrado/descifrado + verificacion de seguridad
+- TestFileIO: save/load archivos en disco
+- TestErrorHandling: errores de formato malformado
+"""
+
+import pytest
+
+from aegisq import (
+    AegisCipher,
+    KeySerializationError,
+    SecurityLevel,
+)
+from aegisq._aegisq_core import load_secret_key_raw
+from aegisq.exceptions import DecryptionError
+from aegisq.keys import (
+    load_public_key,
+    load_secret_key,
+    save_public_key,
+    save_secret_key,
+)
+
+# ── Constantes de formato ─────────────────────────────────────────────────
+
+PEM_PUBLIC_HEADER = "-----BEGIN ML-KEM PUBLIC KEY-----"
+PEM_PUBLIC_FOOTER = "-----END ML-KEM PUBLIC KEY-----"
+PEM_ENCRYPTED_HEADER = "-----BEGIN ENCRYPTED ML-KEM PRIVATE KEY-----"
+PEM_ENCRYPTED_FOOTER = "-----END ENCRYPTED ML-KEM PRIVATE KEY-----"
+BLOB_MAGIC = b"AQPK"
+
+# ── Helper para generar un KeyPair fresco ────────────────────────────────
+
+
+def _fresh_keypair(level: SecurityLevel):
+    cipher = AegisCipher(level=level)
+    return cipher.generate_keypair()
+
+
+def _level_name(level: SecurityLevel) -> str:
+    """Retorna el nombre string del nivel (ej: ML_KEM_768).
+
+    SecurityLevel (PyO3 #[pyclass] eq_int) NO tiene .name como enum.Enum
+    de Python y NO acepta int() directamente. Usamos comparacion por igualdad
+    contra los singletons que importamos.
+    """
+    if level == SecurityLevel.ML_KEM_512:
+        return "ML_KEM_512"
+    if level == SecurityLevel.ML_KEM_768:
+        return "ML_KEM_768"
+    if level == SecurityLevel.ML_KEM_1024:
+        return "ML_KEM_1024"
+    raise ValueError(f"Unknown SecurityLevel: {level!r}")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Llave publica en formato PEM
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestPublicKeyPEM:
+    """PEM-like con header/footer propietarios y Base64 STANDARD."""
+
+    @pytest.mark.parametrize(
+        "level",
+        [
+            SecurityLevel.ML_KEM_512,
+            SecurityLevel.ML_KEM_768,
+            SecurityLevel.ML_KEM_1024,
+        ],
+    )
+    def test_public_key_pem_roundtrip(self, level: SecurityLevel) -> None:
+        """PEM generado por public_key_pem() debe cargarse identico al original."""
+        keypair = _fresh_keypair(level)
+        pem = keypair.public_key_pem()
+
+        from aegisq._aegisq_core import load_public_key_pem
+
+        recovered = load_public_key_pem(pem, level)
+
+        assert recovered == keypair.public_key, (
+            "PEM roundtrip debe recuperar exactamente los bytes de la pk original"
+        )
+
+    def test_public_key_pem_header_footer_format(self) -> None:
+        """El PEM debe tener exactamente el header y footer propietarios."""
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        pem = keypair.public_key_pem()
+
+        assert pem.startswith(PEM_PUBLIC_HEADER), (
+            f"PEM debe empezar con header propietario, got: {pem[:50]!r}"
+        )
+        assert PEM_PUBLIC_FOOTER in pem, (
+            f"PEM debe contener footer propietario, got: ...{pem[-50:]!r}"
+        )
+
+    def test_public_key_pem_line_length_64(self) -> None:
+        """Las lineas del cuerpo Base64 no deben exceder 64 chars."""
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        pem = keypair.public_key_pem()
+
+        # Extraer lineas entre header y footer.
+        lines = pem.strip().split("\n")
+        # Linea 0 = header, linea N = footer; el resto son body.
+        body_lines = lines[1:-1]
+        assert len(body_lines) > 0, "PEM debe tener al menos una linea de body"
+
+        # Todas las lineas intermedias (NO la ultima) deben tener exactamente 64 chars.
+        # La ultima puede ser mas corta porque Base64 rellena con '=' solo al final.
+        for i, line in enumerate(body_lines[:-1]):
+            assert len(line) == 64, (
+                f"Linea intermedia #{i} debe tener exactamente 64 chars, "
+                f"got {len(line)}: {line!r}"
+            )
+        # La ultima linea puede ser mas corta (>= 1 char, <= 64).
+        last_line = body_lines[-1]
+        assert 1 <= len(last_line) <= 64, (
+            f"Ultima linea debe tener entre 1 y 64 chars, got {len(last_line)}: {last_line!r}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Llave publica en formato JSON
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestPublicKeyJSON:
+    """JSON con campos algorithm/level/public_key."""
+
+    def test_public_key_json_roundtrip(self) -> None:
+        """JSON generado debe cargarse y recuperar bytes + nivel."""
+        import json
+
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        js_str = keypair.public_key_json()
+
+        # Validar estructura JSON.
+        parsed = json.loads(js_str)
+        assert parsed["algorithm"] == "ML-KEM"
+        assert parsed["level"] == "ML_KEM_768"
+        assert "public_key" in parsed
+
+        # Round-trip via la API de carga.
+        from aegisq._aegisq_core import load_public_key_json
+
+        recovered_pk, recovered_level = load_public_key_json(js_str)
+        assert recovered_pk == keypair.public_key
+        assert recovered_level == SecurityLevel.ML_KEM_768
+
+    def test_public_key_json_contains_level_field(self) -> None:
+        """El JSON debe contener el campo level como string UPPER_CASE."""
+        import json
+
+        for level in [
+            SecurityLevel.ML_KEM_512,
+            SecurityLevel.ML_KEM_768,
+            SecurityLevel.ML_KEM_1024,
+        ]:
+            keypair = _fresh_keypair(level)
+            parsed = json.loads(keypair.public_key_json())
+
+            expected_name = _level_name(level)
+            assert parsed["level"] == expected_name, (
+                f"JSON debe contener level={expected_name!r}, got {parsed['level']!r}"
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Llave secreta cifrada (wrap/unwrap)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestSecretKeyWrapUnwrap:
+    """AES-256-GCM + HKDF-SHA3-256 sobre la secret key."""
+
+    def test_secret_key_wrap_unwrap_roundtrip(self) -> None:
+        """Wrap + unwrap con contrasena correcta recupera bytes originales."""
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        password = b"correct-horse-battery-staple"
+
+        blob = keypair.export_secret_key_raw(password)
+        assert isinstance(blob, bytes)
+        assert len(blob) > 0
+
+        recovered_sk, recovered_level = load_secret_key_raw(blob, password)
+        assert recovered_sk == keypair.secret_key
+        assert recovered_level == SecurityLevel.ML_KEM_768
+
+    def test_secret_key_wrong_password_raises_decryption_error(self) -> None:
+        """Contrasena incorrecta debe lanzar DecryptionError (no KeySerializationError)."""
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        blob = keypair.export_secret_key_raw(b"correct-password")
+
+        with pytest.raises(DecryptionError):
+            load_secret_key_raw(blob, b"WRONG-password")
+
+    def test_secret_key_pem_header_footer_format(self) -> None:
+        """El PEM de la sk cifrada debe tener header ENCRYPTED propietario."""
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        pem = keypair.export_secret_key_pem(b"pwd")
+
+        assert pem.startswith(PEM_ENCRYPTED_HEADER)
+        assert PEM_ENCRYPTED_FOOTER in pem
+
+    def test_secret_key_blob_magic_bytes(self) -> None:
+        """El blob raw debe empezar con los magic bytes 'AQPK'."""
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        blob = keypair.export_secret_key_raw(b"pwd")
+
+        assert blob[:4] == BLOB_MAGIC, (
+            f"Blob debe empezar con magic {BLOB_MAGIC!r}, got {blob[:4]!r}"
+        )
+        # Version = 1 (byte 4), level_id = 1 para ML_KEM_768 (byte 5)
+        assert blob[4] == 1, f"Version debe ser 1, got {blob[4]}"
+        assert blob[5] == 1, f"level_id para ML_KEM_768 debe ser 1, got {blob[5]}"
+
+    def test_export_secret_key_never_exposes_raw_in_pem(self) -> None:
+        """Verificacion CRITICA de seguridad: los bytes de secret_key NO
+        deben aparecer literalmente en el PEM cifrado.
+        """
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+
+        # Usar un secret_key con patron reconocible (no aleatorio puro).
+        # Esto aumenta la probabilidad de detectar filtracion literal.
+        # Como keypair.secret_key es aleatorio, agarramos 32 bytes del medio
+        # y los buscamos como substring en el PEM.
+        sample = bytes(keypair.secret_key[100:132])  # 32 bytes unicos
+
+        pem = keypair.export_secret_key_pem(b"pwd")
+
+        assert sample not in pem.encode("utf-8"), (
+            "BUG DE SEGURIDAD: bytes de secret_key aparecen literalmente "
+            "en el PEM cifrado. El cifrado AES-GCM no esta funcionando."
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# File I/O (save/load a disco)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestFileIO:
+    """save_* / load_* escriben y leen archivos correctamente."""
+
+    def test_save_and_load_public_key_file_pem(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        pem_path = tmp_path / "recipient.pem"  # type: ignore[operator]
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+
+        save_public_key(keypair, pem_path)
+        assert pem_path.exists()
+        assert pem_path.stat().st_size > 0
+
+        recovered = load_public_key(pem_path, level=SecurityLevel.ML_KEM_768)
+        assert recovered == keypair.public_key
+
+    def test_save_and_load_public_key_file_json(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        json_path = tmp_path / "recipient.json"  # type: ignore[operator]
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+
+        save_public_key(keypair, json_path, fmt="json")
+        assert json_path.exists()
+
+        # Para JSON el level se extrae del archivo, no se pasa.
+        recovered = load_public_key(json_path)
+        assert recovered == keypair.public_key
+
+    def test_save_and_load_secret_key_file(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        sk_path = tmp_path / "private.key"  # type: ignore[operator]
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+        password = b"strong-password-123"
+
+        save_secret_key(keypair, sk_path, password=password)
+        assert sk_path.exists()
+        assert sk_path.stat().st_size > 0
+
+        recovered = load_secret_key(sk_path, password=password)
+        assert recovered == keypair.secret_key
+
+    def test_load_secret_key_wrong_password(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        sk_path = tmp_path / "private.key"  # type: ignore[operator]
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+
+        save_secret_key(keypair, sk_path, password=b"correct")
+        with pytest.raises(DecryptionError):
+            load_secret_key(sk_path, password=b"WRONG")
+
+    def test_load_public_key_autodetect_format(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """load_public_key debe detectar PEM vs JSON por la primera linea."""
+        keypair = _fresh_keypair(SecurityLevel.ML_KEM_768)
+
+        # PEM
+        pem_path = tmp_path / "k.pem"  # type: ignore[operator]
+        save_public_key(keypair, pem_path)
+        assert load_public_key(pem_path, level=SecurityLevel.ML_KEM_768) == (
+            keypair.public_key
+        )
+
+        # JSON
+        json_path = tmp_path / "k.json"  # type: ignore[operator]
+        save_public_key(keypair, json_path, fmt="json")
+        assert load_public_key(json_path) == keypair.public_key
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Manejo de errores
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestErrorHandling:
+    """Formatos malformados deben lanzar KeySerializationError (no panic)."""
+
+    def test_key_serialization_error_on_invalid_pem(self) -> None:
+        from aegisq._aegisq_core import load_public_key_pem
+
+        # PEM sin header
+        with pytest.raises(KeySerializationError):
+            load_public_key_pem("esto no es un PEM valido", SecurityLevel.ML_KEM_768)
+
+        # PEM sin footer
+        broken = f"{PEM_PUBLIC_HEADER}\nQUJDREVG\n"
+        with pytest.raises(KeySerializationError):
+            load_public_key_pem(broken, SecurityLevel.ML_KEM_768)
+
+        # PEM con Base64 invalido en el cuerpo
+        broken_b64 = f"{PEM_PUBLIC_HEADER}\n!!! no es base64 !!!\n{PEM_PUBLIC_FOOTER}\n"
+        with pytest.raises(KeySerializationError):
+            load_public_key_pem(broken_b64, SecurityLevel.ML_KEM_768)
+
+    def test_key_serialization_error_on_truncated_blob(self) -> None:
+        """Blob demasiado corto debe lanzar KeySerializationError."""
+        truncated = b"AQPK" + b"\x01" * 5  # magic + 5 bytes, muy corto
+        with pytest.raises(KeySerializationError):
+            load_secret_key_raw(truncated, b"pwd")
+
+        # Magic incorrecto
+        bad_magic = b"XXXX" + b"\x00" * 100
+        with pytest.raises(KeySerializationError):
+            load_secret_key_raw(bad_magic, b"pwd")


### PR DESCRIPTION
## Summary

v1.3.0 adds two orthogonal features:

1. **Key serialization** — export/import keys in standard formats (PEM-like
   proprietary / JSON / AES-256-GCM encrypted blob with password).
2. **`cargo-deny` CI gate** — license + ban + source + advisory audit.

## What's new

### Key serialization (3 layers)

**Capa 1 — Rust pure (\`aegisq-core\`)**
- New \`kdf.rs\`: HMAC-SHA3-256 + HKDF-SHA3-256 manual implementations
  (block size 136 bytes per NIST SP 800-185).
- New \`key_wrap.rs\`: \`wrap_secret_key\` / \`unwrap_secret_key\` using
  AES-256-GCM + HKDF-SHA3-256. Blob layout:
  \`magic("AQPK") | version(1) | level_id(1) | salt(16) | nonce(12) | ciphertext | tag(16)\`.
- New validation helpers \`validate_public_key_size\` / \`validate_secret_key_size\`.
- New error variant \`KeySerializationError\`.

**Capa 2 — PyO3 bridge (\`aegisq-pyo3\`)**
- 4 new \`#[pymethods]\` on \`KeyPair\`: \`public_key_pem\`, \`public_key_json\`,
  \`export_secret_key_raw\`, \`export_secret_key_pem\`.
- 4 new \`#[pyfunction]\`s in \`key_io_bindings.rs\`: \`load_public_key_pem\`,
  \`load_public_key_json\`, \`load_secret_key_raw\`, \`load_secret_key_pem\`.
- New Python exception \`KeySerializationError\` mapped from Rust error.
- \`getrandom\` + \`base64\` added as direct deps (re-added after commit #34
  removed \`base64\` as transitively-unused).

**Capa 3 — Python high-level (\`aegisq/\`)**
- New \`keys.py\` module: \`save_public_key\`, \`load_public_key\` (auto-detect
  PEM/JSON), \`save_secret_key\`, \`load_secret_key\`, plus helper wrappers.
- Updated \`__init__.py\` and \`exceptions.py\` to re-export new symbols.
- Updated type stubs in \`_aegisq_core.pyi\`.

### Security
- **Secret keys NEVER exported in plaintext** — always AES-256-GCM encrypted
  with HKDF-SHA3-256 derived key.
- **Wrong password returns \`DecryptionFailed\`** (indistinguishable from
  corrupted blob — anti side-channel).
- **HMAC-SHA3-256 with correct 136-byte block size** (NIST SP 800-185), verified
  against Python \`hashlib.sha3_256\` stdlib as independent oracle.

### CI gate (\`cargo-deny\`)
- New \`deny.toml\` (cargo-deny 0.19 schema) — allow-list of approved licenses
  (MIT, Apache-2.0, BSD-2/3, ISC, Unicode-3.0/DFS-2016, Zlib), bans for \`ring\`,
  \`openssl\`, \`openssl-sys\`, sources restricted to crates.io.
- The existing \`deny\` job in \`.github/workflows/ci.yml\` (matrix of
  \`advisories\` and \`bans licenses sources\`) is now backed by this config.

### Dependency fix
- Bumped \`pyo3\` 0.28.3 → 0.29.0 to fix **RUSTSEC-2026-0177** (missing
  \`Sync\` bound on \`PyCFunction::new_closure\` — thread-safety bug under
  free-threaded Python).

## Verification

- \`cargo test --workspace\` → **181 passed** (+21 new in \`kdf\` /\`key_wrap\` /\`kem::validation_tests\`)
- \`pytest tests/python/\` → **151 passed** (+19 new in \`test_key_serialization.py\`)
- \`cargo deny check\` → **advisories ok, bans ok, licenses ok, sources ok**
- \`ruff check aegisq/\` + \`ruff format --check aegisq/\` → clean
- End-to-end smoke test via \`maturin develop\`: roundtrips OK, security
  tests pass (secret_key raw bytes do NOT appear in encrypted PEM).

## Test coverage (new)

\`tests/python/test_key_serialization.py\` — 19 tests in 5 classes:
- \`TestPublicKeyPEM\` (5): roundtrip x3 levels, header/footer, line length
- \`TestPublicKeyJSON\` (2): roundtrip, contains level field
- \`TestSecretKeyWrapUnwrap\` (5): roundtrip, wrong password, PEM header,
  magic bytes, **security: raw bytes never appear in PEM**
- \`TestFileIO\` (5): save/load PEM/JSON/secret on disk, wrong password from
  file, auto-detect format
- \`TestErrorHandling\` (2): \`KeySerializationError\` on invalid PEM, on
  truncated blob

## Commits

- \`a738135\` chore(release): bump version 1.2.0 -> 1.3.0
- \`caefbcc\` fix(deps): bump pyo3 0.28 -> 0.29 (RUSTSEC-2026-0177)
- \`8e89ab1\` ci: add cargo-deny config (deny.toml)
- \`8e32c77\` test(python): 19 tests for key serialization
- \`0978740\` feat(python): keys.py + exceptions + stubs
- \`fb2e5bc\` feat(pyo3): key serialization bindings
- \`370d17d\` feat(core): HKDF/HMAC-SHA3-256 + key_wrap

## Notes for reviewer

- **Schema corrections vs spec §2.2**: the original spec used deprecated keys
  in cargo-deny 0.13 (\`[licenses] deny/unlicensed/copyleft\`). Updated to
  the current cargo-deny 0.19 schema where these are removed and the
  default behavior already covers them.
- **PyO3 0.29 bump**: source code required no changes — our closures already
  satisfy \`Send + 'static\`. All tests pass on 0.29.0.