### PR TITLE
chore(sync): post-release merge main → develop (v1.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "aegisq-core"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "aegisq-pyo3"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aegisq-core",
  "base64",


### PR DESCRIPTION
## Post-release sync

Syncs the squash-merged v1.3.0 release from \`main\` back into \`develop\`,
as required by the GitFlow workflow (AGENTS.md §12.4).

## Source of changes

The squash merge from PR #42 brought v1.3.0 to \`main\` (commit \`a7e74ad\`):
- Key serialization (PEM-like, JSON, AES-256-GCM encrypted blob)
- aegisq.keys module + KeySerializationError exception
- 19 new pytest tests
- cargo-deny gate in CI (deny.toml)
- pyo3 0.28.3 → 0.29.0 (RUSTSEC-2026-0177)
- Release workflow published \`aegisq-pqc-1.3.0\` to PyPI production
- GitHub Release v1.3.0 created

After this merge, \`develop\` and \`main\` are in sync and ready for the
next feature cycle.